### PR TITLE
Allow only one vote per account/proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "futures",
  "hex",
  "image",
+ "imhamt",
  "jcli",
  "jormungandr-lib",
  "jormungandr-testing-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", bran
 chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+imhamt = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chrono = "0.4"
 jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }

--- a/src/recovery/tally.rs
+++ b/src/recovery/tally.rs
@@ -20,9 +20,10 @@ use chain_impl_mockchain::{
     ledger::{self, Ledger},
     transaction::InputEnum,
     value::ValueError,
-    vote::{CommitteeId, Payload},
+    vote::{CommitteeId, Payload, VoteError, VotePlanLedgerError},
 };
 use chain_time::{Epoch, Slot, SlotDuration, TimeEra, TimeFrame, Timeline};
+use imhamt::UpdateError;
 use jormungandr_lib::crypto::account::Identifier;
 use jormungandr_lib::crypto::hash::Hash;
 use jormungandr_lib::interfaces::CommitteeIdDef;
@@ -495,7 +496,9 @@ pub fn recover_ledger_from_logs(
                 ))) => {
                     warn!("Account balance not enough to process fragment")
                 }
-                Err(_) => unreachable!("Should be impossible to fail, since we should be using proper spending counters and signatures"),
+                // allows this as it has nothing to do with spending counters / signatures
+                Err(ledger::Error::VotePlan(VotePlanLedgerError::VoteError{reason: UpdateError::ValueCallbackError(VoteError::AlreadyVoted), ..})) => (),
+                Err(_) => unreachable!("Should be impossible to fail, since we should be using proper spending counters and signatures")
             }
         }
     }

--- a/tests/tally/generator.rs
+++ b/tests/tally/generator.rs
@@ -171,21 +171,18 @@ impl VoteRoundGenerator {
 
                 let address =
                     account_from_slice(&transaction.as_slice()).expect("utxo votes not supported");
-                let update_voteplan = self
-                    .voteplan_managers
-                    .get(&vote_plan_id)
-                    .unwrap()
-                    .vote(
-                        self.voteplan_managers
-                            .get(&vote_plan_id)
-                            .expect("vote plan not found")
-                            .plan()
-                            .vote_start(),
-                        address,
-                        vote_cast,
-                    )
-                    .unwrap();
-                self.voteplan_managers.insert(vote_plan_id, update_voteplan);
+                let update_voteplan = self.voteplan_managers.get(&vote_plan_id).unwrap().vote(
+                    self.voteplan_managers
+                        .get(&vote_plan_id)
+                        .expect("vote plan not found")
+                        .plan()
+                        .vote_start(),
+                    address,
+                    vote_cast,
+                );
+                if let Ok(update_voteplan) = update_voteplan {
+                    self.voteplan_managers.insert(vote_plan_id, update_voteplan);
+                }
             } else {
                 panic!("a non vote fragment was generated");
             };

--- a/tests/tally/main.rs
+++ b/tests/tally/main.rs
@@ -273,8 +273,8 @@ fn replay_not_counted() {
         .unwrap();
     dbg!(&tally);
     assert_eq!(tally.result().unwrap().results()[0], 0.into());
-    assert_eq!(tally.result().unwrap().results()[1], 0.into());
-    assert!(tally.result().unwrap().results()[2] > 0.into());
+    assert!(tally.result().unwrap().results()[1] > 0.into());
+    assert_eq!(tally.result().unwrap().results()[2], 0.into());
     assert_eq!(failed_fragments.len(), 1);
 }
 


### PR DESCRIPTION
Update tests/bin to handle cases in which an account vote for more
than one proposal.
The testing generator now produces also invalid transactions, which
should be handled correctly by the implementation.