### PR TITLE
enable private vote stats for archive

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -83,7 +83,9 @@ pub fn generate_archive_files(jormungandr_database: &Path, output_dir: &Path) ->
                 let choice = match certificate.payload() {
                     chain_impl_mockchain::vote::Payload::Public { choice } => choice.as_byte(),
                     chain_impl_mockchain::vote::Payload::Private { .. } => {
-                        unimplemented!("private votes are not supported yet")
+                        // zeroing data to enable private voting support
+                        // (at least everying exception choice, since it is disabled by desing in private vote)
+                        0u8
                     }
                 };
 


### PR DESCRIPTION
Simple fix, not to panic when voting was private, but zeroing choices