### PR TITLE
adjustment for ideascale import after tests

### DIFF
--- a/src/ideascale/mod.rs
+++ b/src/ideascale/mod.rs
@@ -85,7 +85,7 @@ pub async fn fetch_all(
         funnels,
         fund: funds
             .into_iter()
-            .find(|f| f.name.as_ref().contains(&format!("Fund{}", fund)))
+            .find(|f| f.name.as_ref().contains(&format!("Fund {}", fund)))
             .unwrap_or_else(|| panic!("Selected fund {}, wasn't among the available funds", fund)),
         challenges: challenges.into_iter().map(|c| (c.id, c)).collect(),
         proposals: proposals.map(|p| (p.proposal_id, p)).collect(),

--- a/src/ideascale/models/custom_fields.rs
+++ b/src/ideascale/models/custom_fields.rs
@@ -21,7 +21,7 @@ impl Default for CustomFieldTags {
             proposal_solution: "problem_solution".to_string(),
             proposal_brief: "challenge_brief".to_string(),
             proposal_importance: "importance".to_string(),
-            proposal_goal: "describe_your_solution_to_the_problem".to_string(),
+            proposal_goal: "how_does_success_look_like_".to_string(),
             proposal_metrics: "key_metrics_to_measure".to_string(),
             proposal_public_key: "ada_payment_address".to_string(),
             proposal_funds: "requested_funds".to_string(),

--- a/src/ideascale/models/de.rs
+++ b/src/ideascale/models/de.rs
@@ -172,7 +172,7 @@ fn deserialize_rewards<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64
     if rewards_str.starts_with("0 ada") {
         return Ok(0);
     }
-    sscanf::scanf!(rewards_str.trim_end(), "${} in ada", String)
+    sscanf::scanf!(rewards_str.trim_end(), "${} in", String)
         // trim all . or , in between numbers
         .map(|mut s: String| {
             s.retain(|c: char| c.is_numeric() || matches!(c, '.'));

--- a/tests/notifications/main.rs
+++ b/tests/notifications/main.rs
@@ -45,7 +45,7 @@ pub fn sanity_notification() {
 
 fn get_env<S: Into<String>>(env_name: S) -> String {
     let env_name = env_name.into();
-    std::env::var(&env_name).expect(&format!("{} not defined", env_name))
+    std::env::var(&env_name).unwrap_or_else(|_| panic!("{} not defined", env_name))
 }
 
 fn create_message_file<P: AsRef<Path>, S: Into<String>>(path: P, message: S) {


### PR DESCRIPTION
Fixed some minor stuff when testing ideascale import:

- added white-space when querying for particular fund
- renamed `proposal goal` mapping
- made rewards deserializer more universal since it can hold different crypto from ada
- clippy issues