### PR TITLE
Exclude addresses from total stake

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Options:
   --vit-station-url TEXT          [default: https://servicing-
                                   station.vit.iohk.io]
 
+  --committee-keys-path TEXT
   --install-completion [bash|zsh|fish|powershell|pwsh]
                                   Install completion for the specified shell.
   --show-completion [bash|zsh|fish|powershell|pwsh]

--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -1,4 +1,4 @@
 httpx==0.17.1
 pydantic==1.8.1
 typer==0.3.2
-pyaml==6.0
+pyYAML==6.0


### PR DESCRIPTION
This pull request enable an option in the `proposers_rewards.py` script to exclude certain addresses (e.g. committee) from the calculation of the total stake used to determine the approval threshold for proposals.

The new option refers to a local json file containing the address to be excluded in the format:
```
[
  {"address": "ca1q..."},
  {"address": "ca1q..."}
]
```

It also fixes a typo in the python dependencies and a proper sanitization for output filenames.