### PR TITLE
remove chrono as a direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "chain-storage",
  "chain-time",
  "chain-vote",
- "chrono",
  "csv",
  "fixed",
  "futures",
@@ -426,6 +425,7 @@ dependencies = [
  "symmetric-cipher",
  "thiserror",
  "thor",
+ "time 0.3.7",
  "tokio",
  "url",
  "versionisator",
@@ -574,7 +574,7 @@ name = "chain-vote"
 version = "0.1.0"
 source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#b2128c8522ebf650fe13fe898c04bdc1de2527a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "chain-core",
  "chain-crypto",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch 
 chain-storage = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
-chrono = "0.4"
+time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 itertools = "0.10"
-jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
+jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master"}
 jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-integration-tests = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-automation = { git = "https://github.com/input-output-hk/jormungandr.git",  branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 itertools = "0.10"
-jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master"}
+jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-integration-tests = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 jormungandr-automation = { git = "https://github.com/input-output-hk/jormungandr.git",  branch = "master" }

--- a/src/bin/cli/logs/sentry/download.rs
+++ b/src/bin/cli/logs/sentry/download.rs
@@ -4,9 +4,9 @@ use jcli_lib::utils::io::open_file_write;
 
 use std::path::PathBuf;
 
-use chrono::{DateTime, FixedOffset};
 use std::str::FromStr;
 use structopt::StructOpt;
+use time::OffsetDateTime;
 use url::Url;
 
 const DATE_TIME_TAG: &str = "dateCreated";
@@ -19,11 +19,11 @@ pub enum Mode {
 #[derive(StructOpt)]
 pub struct DateFilter {
     // Optional [From, To] date range, start
-    #[structopt(long, parse(try_from_str = DateTime::parse_from_rfc3339))]
-    from: Option<DateTime<FixedOffset>>,
+    #[structopt(long, parse(try_from_str = parse_datetime_from_rfc3339))]
+    from: Option<OffsetDateTime>,
     // Optional [From, To] date range, end
-    #[structopt(long, parse( try_from_str = DateTime::parse_from_rfc3339))]
-    to: Option<DateTime<FixedOffset>>,
+    #[structopt(long, parse( try_from_str = parse_datetime_from_rfc3339))]
+    to: Option<OffsetDateTime>,
 }
 
 #[derive(StructOpt)]
@@ -165,12 +165,16 @@ fn dump_logs_to_json(logs: &[RawLog], out: PathBuf) -> Result<(), Error> {
     Ok(())
 }
 
-fn date_time_from_raw_log(l: &RawLog) -> DateTime<FixedOffset> {
-    DateTime::parse_from_rfc3339(
+fn date_time_from_raw_log(l: &RawLog) -> OffsetDateTime {
+    parse_datetime_from_rfc3339(
         l.get(DATE_TIME_TAG)
             .expect("A dateCreated entry should be present in sentry logs")
             .as_str()
             .expect("dateCreated should be a str"),
     )
     .expect("A rfc3339 compatible DateTime str")
+}
+
+fn parse_datetime_from_rfc3339(datetime: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(datetime, &time::format_description::well_known::Rfc3339)
 }

--- a/src/bin/cli/notifications/send.rs
+++ b/src/bin/cli/notifications/send.rs
@@ -11,9 +11,9 @@ use catalyst_toolbox::notifications::{
 };
 use jcli_lib::utils::io;
 
-use chrono::{DateTime, FixedOffset};
 use reqwest::Url;
 use structopt::StructOpt;
+use time::OffsetDateTime;
 
 use std::io::Read;
 use std::path::PathBuf;
@@ -39,8 +39,8 @@ pub struct Args {
     application: String,
 
     /// Date and time to send notification of format  "Y-m-d H:M"
-    #[structopt(long, parse(try_from_str=parse_date_time))]
-    send_date: Option<DateTime<FixedOffset>>,
+    #[structopt(long, parse(try_from_str=parse_datetime))]
+    send_date: Option<OffsetDateTime>,
 
     /// Ignore user timezones when sending a message
     #[structopt(long)]
@@ -144,6 +144,6 @@ impl Content {
     }
 }
 
-fn parse_date_time(dt: &str) -> chrono::ParseResult<DateTime<FixedOffset>> {
-    DateTime::parse_from_str(dt, DATETIME_FMT)
+fn parse_datetime(dt: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(dt, &DATETIME_FMT)
 }

--- a/src/notifications/requests/create_message.rs
+++ b/src/notifications/requests/create_message.rs
@@ -1,12 +1,11 @@
-use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
-use std::fmt::Display;
+use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
 
 use thiserror::Error;
 
-pub const DATETIME_FMT: &str = "%Y-%m-%d %H:%M";
+pub const DATETIME_FMT: &[FormatItem] = format_description!("[year]-[month]-[day] [hour]:[minute]");
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
@@ -80,12 +79,10 @@ impl ContentSettingsBuilder {
         Self::default()
     }
 
-    pub fn with_send_date<Tz>(mut self, datetime: DateTime<Tz>) -> Self
-    where
-        Tz: chrono::TimeZone,
-        Tz::Offset: Display,
-    {
-        self.send_date = datetime.format("%Y-%m-%d %H:%M").to_string();
+    pub fn with_send_date(mut self, datetime: OffsetDateTime) -> Self {
+        self.send_date = datetime
+            .format(&DATETIME_FMT)
+            .expect("could not format date");
         self
     }
 


### PR DESCRIPTION
Remove chrono as a direct dependency. There are still traces of it in vit-servicing-station and other dependencies, but this is a first step