### PR TITLE
Output reward address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,8 @@ dependencies = [
  "once_cell",
  "predicates 1.0.8",
  "qrcode",
+ "quickcheck",
+ "quickcheck_macros",
  "quircs",
  "rand 0.8.4",
  "rand_chacha 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,12 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "az"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
-
-[[package]]
 name = "backtrace"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,7 +376,6 @@ dependencies = [
  "chain-vote",
  "chrono",
  "csv",
- "fixed",
  "futures",
  "gag",
  "graphql_client",
@@ -1120,19 +1113,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
-]
-
-[[package]]
-name = "fixed"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a9a8cb2e34880a498f09367089339bda5e12d6f871640f947850f7113058c0"
-dependencies = [
- "az",
- "bytemuck",
- "half",
- "serde",
- "typenum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ version = "0.3.0"
 dependencies = [
  "assert_cmd 0.10.2",
  "assert_fs",
+ "bech32 0.8.1",
  "chain-addr",
  "chain-core",
  "chain-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,6 @@ jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", 
 jormungandr-testing-utils = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "catalyst-fund7" }
 jormungandr-integration-tests = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "catalyst-fund7" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }
-# TODO: Remove fixed and migrate to rust_decimal
-fixed = { version = "1.7", features = ["serde"] }
 rust_decimal = "1.16"
 futures = "0.3"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ symmetric-cipher = { git = "https://github.com/input-output-hk/chain-wallet-libs
 graphql_client = "0.10"
 gag = "1"
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "catalyst-fund7" }
+quickcheck = "0.9"
+quickcheck_macros = "0.9"
 
 [dev-dependencies]
 rand_chacha = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 
 [dependencies]
 assert_fs = "1"
+bech32 = "0.8.1"
 csv = "1.1"
 wallet = { git = "https://github.com/input-output-hk/chain-wallet-libs.git", branch = "catalyst-fund7" }
 chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "catalyst-fund7" }

--- a/src/bin/cli/rewards/mod.rs
+++ b/src/bin/cli/rewards/mod.rs
@@ -19,6 +19,12 @@ pub enum Error {
 
     #[error("{0}")]
     InvalidInput(String),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 }
 
 #[derive(StructOpt)]

--- a/src/bin/cli/rewards/voters.rs
+++ b/src/bin/cli/rewards/voters.rs
@@ -1,13 +1,14 @@
 use super::Error;
 use catalyst_toolbox::rewards::voters::{calc_voter_rewards, Rewards, VoteCount};
 use catalyst_toolbox::snapshot::{MainnetRewardAddress, Snapshot};
+use catalyst_toolbox::utils::assert_are_close;
 
 use jcli_lib::jcli_lib::block::Common;
 use jormungandr_lib::interfaces::Block0Configuration;
 
 use structopt::StructOpt;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 #[derive(StructOpt)]
@@ -39,7 +40,7 @@ pub struct VotersRewards {
 
 fn write_rewards_results(
     common: Common,
-    rewards: &HashMap<MainnetRewardAddress, Rewards>,
+    rewards: &BTreeMap<MainnetRewardAddress, Rewards>,
 ) -> Result<(), Error> {
     let writer = common.open_output()?;
     let header = ["Address", "Reward for the voter (lovelace)"];
@@ -83,6 +84,9 @@ impl VotersRewards {
             snapshot,
             Rewards::from(total_rewards),
         );
+
+        let actual_rewards = results.values().sum::<Rewards>();
+        assert_are_close(actual_rewards, Rewards::from(total_rewards));
 
         write_rewards_results(common, &results)?;
         Ok(())

--- a/src/bin/cli/rewards/voters.rs
+++ b/src/bin/cli/rewards/voters.rs
@@ -1,6 +1,7 @@
 use super::Error;
 use catalyst_toolbox::rewards::voters::{
-    calculate_reward_share, calculate_stake, reward_from_share, ADA_TO_LOVELACE_FACTOR,
+    calculate_reward_share, calculate_stake, reward_from_share, vote_count_with_addresses,
+    AddressesVoteCount, Rewards, VoteCount, ADA_TO_LOVELACE_FACTOR,
 };
 
 use chain_addr::{Discrimination, Kind};
@@ -8,11 +9,11 @@ use chain_impl_mockchain::vote::CommitteeId;
 use jcli_lib::jcli_lib::block::Common;
 use jormungandr_lib::interfaces::{Address, Block0Configuration};
 
-use fixed::types::U64F64;
 use structopt::StructOpt;
 
 use std::collections::{HashMap, HashSet};
 use std::ops::Div;
+use std::path::PathBuf;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -20,14 +21,20 @@ pub struct VotersRewards {
     #[structopt(flatten)]
     common: Common,
     /// Reward (in LOVELACE) to be distributed
-    #[structopt(long = "total-rewards")]
+    #[structopt(long)]
     total_rewards: u64,
+
+    #[structopt(long)]
+    votes_count_path: PathBuf,
+
+    #[structopt(long, default_value)]
+    vote_threshold: u64,
 }
 
 fn write_rewards_results(
     common: Common,
     stake_per_voter: &HashMap<&Address, u64>,
-    share_results: &HashMap<&Address, U64F64>,
+    share_results: &HashMap<&Address, Rewards>,
     total_rewards: u64,
 ) -> Result<(), Error> {
     let writer = common.open_output()?;
@@ -61,10 +68,20 @@ impl VotersRewards {
         let VotersRewards {
             common,
             total_rewards,
+            votes_count_path,
+            vote_threshold,
         } = self;
         let block = common.input.load_block()?;
         let block0 = Block0Configuration::from_block(&block)
             .map_err(jcli_lib::jcli_lib::block::Error::BuildingGenesisFromBlock0Failed)?;
+
+        let vote_count: VoteCount = serde_json::from_reader(jcli_lib::utils::io::open_file_read(
+            &Some(votes_count_path),
+        )?)?;
+
+        let addresses_vote_count: AddressesVoteCount =
+            vote_count_with_addresses(vote_count, &block0);
+
         let committee_keys: HashSet<Address> = block0
             .blockchain_configuration
             .committees
@@ -79,7 +96,12 @@ impl VotersRewards {
             .collect();
 
         let (total_stake, stake_per_voter) = calculate_stake(&committee_keys, &block0);
-        let rewards = calculate_reward_share(total_stake, &stake_per_voter);
+        let rewards = calculate_reward_share(
+            total_stake,
+            &stake_per_voter,
+            &addresses_vote_count,
+            vote_threshold,
+        );
         write_rewards_results(common, &stake_per_voter, &rewards, total_rewards)?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod logs;
 pub mod notifications;
 pub mod recovery;
 pub mod rewards;
+pub mod snapshot;
 pub mod utils;
 pub mod vca_reviews;
 pub mod vote_check;

--- a/src/rewards/voters.rs
+++ b/src/rewards/voters.rs
@@ -155,8 +155,6 @@ pub fn calc_voter_rewards(
         .collect();
     let (total_active_stake, stake_per_voter) =
         calculate_active_stake(&committee_keys, block0, &active_addresses);
-    dbg!(total_active_stake);
-    dbg!(&stake_per_voter);
     let rewards = calculate_reward(
         total_active_stake,
         &stake_per_voter,

--- a/src/rewards/voters.rs
+++ b/src/rewards/voters.rs
@@ -1,7 +1,7 @@
-use fixed::types::U64F64;
-
+use crate::snapshot::{MainnetRewardAddress, Snapshot};
 use chain_addr::{Discrimination, Kind};
 use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
+use chain_impl_mockchain::vote::CommitteeId;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 
@@ -10,7 +10,7 @@ use jormungandr_lib::interfaces::{Address, Block0Configuration, Initial};
 pub const ADA_TO_LOVELACE_FACTOR: u64 = 1_000_000;
 pub type Rewards = Decimal;
 
-pub fn calculate_active_stake<'address>(
+fn calculate_active_stake<'address>(
     committee_keys: &HashSet<Address>,
     block0: &'address Block0Configuration,
     active_addresses: &ActiveAddresses,
@@ -42,17 +42,18 @@ pub fn calculate_active_stake<'address>(
     (total_stake, stake_per_voter)
 }
 
-pub fn calculate_reward_share<'address>(
+fn calculate_reward<'address>(
     total_stake: u64,
     stake_per_voter: &HashMap<&'address Address, u64>,
     active_addresses: &ActiveAddresses,
+    total_rewards: Rewards,
 ) -> HashMap<&'address Address, Rewards> {
     stake_per_voter
         .iter()
         .map(|(k, v)| {
             // if it doesnt appear in the votes count, it means it did not vote
             let reward = if active_addresses.contains(k) {
-                Rewards::from(*v) / Rewards::from(total_stake)
+                Rewards::from(*v) / Rewards::from(total_stake) * total_rewards
             } else {
                 Rewards::ZERO
             };
@@ -61,15 +62,10 @@ pub fn calculate_reward_share<'address>(
         .collect()
 }
 
-/// get the proportional reward from a share and total rewards amount
-pub fn reward_from_share(share: Rewards, total_reward: u64) -> Rewards {
-    Rewards::from(total_reward) * share
-}
-
 pub type VoteCount = HashMap<String, u64>;
 pub type ActiveAddresses = HashSet<Address>;
 
-pub fn active_addresses(
+fn active_addresses(
     vote_count: VoteCount,
     block0: &Block0Configuration,
     threshold: u64,
@@ -106,4 +102,66 @@ fn account_hex_to_address(
                 .into(),
         ),
     )))
+}
+
+fn rewards_to_mainnet_addresses(
+    rewards: HashMap<&'_ Address, Rewards>,
+    snapshot: Snapshot,
+) -> HashMap<MainnetRewardAddress, Rewards> {
+    let mut res = HashMap::new();
+    for (addr, reward) in rewards {
+        let registrations = snapshot.registrations_for_voting_key(
+            addr.as_ref()
+                .public_key()
+                .expect("non account address")
+                .clone(),
+        );
+        let total_stake = registrations
+            .iter()
+            .map(|reg| Rewards::from(u64::from(reg.stake)))
+            .sum::<Rewards>();
+        dbg!(total_stake);
+        dbg!(&registrations);
+
+        for reg in registrations {
+            *res.entry(reg.reward_addr).or_default() +=
+                reward * Rewards::from(u64::from(reg.stake)) / total_stake;
+        }
+    }
+
+    res
+}
+
+pub fn calc_voter_rewards(
+    vote_count: VoteCount,
+    vote_threshold: u64,
+    block0: &Block0Configuration,
+    snapshot: Snapshot,
+    total_rewards: Rewards,
+) -> HashMap<MainnetRewardAddress, Rewards> {
+    let active_addresses = active_addresses(vote_count, block0, vote_threshold);
+
+    let committee_keys: HashSet<Address> = block0
+        .blockchain_configuration
+        .committees
+        .iter()
+        .cloned()
+        .map(|id| {
+            let id = CommitteeId::from(id);
+            let pk = id.public_key();
+
+            chain_addr::Address(Discrimination::Production, Kind::Account(pk)).into()
+        })
+        .collect();
+    let (total_active_stake, stake_per_voter) =
+        calculate_active_stake(&committee_keys, block0, &active_addresses);
+    rewards_to_mainnet_addresses(
+        calculate_reward(
+            total_active_stake,
+            &stake_per_voter,
+            &active_addresses,
+            total_rewards,
+        ),
+        snapshot,
+    )
 }

--- a/src/rewards/voters.rs
+++ b/src/rewards/voters.rs
@@ -118,14 +118,12 @@ fn rewards_to_mainnet_addresses(
         );
         let total_stake = registrations
             .iter()
-            .map(|reg| Rewards::from(u64::from(reg.stake)))
+            .map(|reg| Rewards::from(u64::from(reg.voting_power)))
             .sum::<Rewards>();
-        dbg!(total_stake);
-        dbg!(&registrations);
 
         for reg in registrations {
-            *res.entry(reg.reward_addr).or_default() +=
-                reward * Rewards::from(u64::from(reg.stake)) / total_stake;
+            *res.entry(reg.reward_address).or_default() +=
+                reward * Rewards::from(u64::from(reg.voting_power)) / total_stake;
         }
     }
 
@@ -161,7 +159,6 @@ pub fn calc_voter_rewards(
         &active_addresses,
         total_rewards,
     );
-    dbg!(&rewards);
     rewards_to_mainnet_addresses(rewards, snapshot)
 }
 
@@ -238,22 +235,20 @@ mod tests {
 
     #[test]
     fn test_mapping() {
-        let mut raw_snapshot = HashMap::new();
+        let mut raw_snapshot = Vec::new();
         let voting_pub_key = Identifier::from_hex(&hex::encode([0; 32])).unwrap();
 
         let mut total_stake = 0u64;
         for i in 1..10u64 {
-            let stake_key = i.to_string();
-            let reward_addr = i.to_string();
-            let stake: Stake = i.into();
-            raw_snapshot.insert(
-                stake_key,
-                CatalystRegistration {
-                    stake,
-                    reward_addr,
-                    voting_pub_key: voting_pub_key.clone(),
-                },
-            );
+            let stake_public_key = i.to_string();
+            let reward_address = i.to_string();
+            let voting_power: Stake = i.into();
+            raw_snapshot.push(CatalystRegistration {
+                stake_public_key,
+                voting_power,
+                reward_address,
+                voting_public_key: voting_pub_key.clone(),
+            });
             total_stake += i;
         }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+
+use chain_addr::{Discrimination, Kind};
+use jormungandr_lib::crypto::account::Identifier;
+use jormungandr_lib::interfaces::{Address, Initial, InitialUTxO, Stake, Value};
+use serde::Deserialize;
+
+pub type MainnetRewardAddress = String;
+pub type MainnetStakeAddress = String;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct CatalystRegistration {
+    pub stake: Stake,
+    pub reward_addr: MainnetRewardAddress,
+    pub voting_pub_key: Identifier,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct RawSnapshot(HashMap<MainnetStakeAddress, CatalystRegistration>);
+
+#[derive(Clone, Debug)]
+pub struct Snapshot {
+    // a raw public key is preferred so that we don't have to worry about discrimination when deserializing from
+    // a CIP-15 compatible encoding
+    inner: HashMap<Identifier, Vec<(MainnetRewardAddress, Stake)>>,
+    stake_threshold: Stake,
+}
+
+impl Snapshot {
+    pub fn from_raw_snapshot(raw_snapshot: RawSnapshot, stake_threshold: Stake) -> Self {
+        Self {
+            inner: raw_snapshot
+                .0
+                .into_iter()
+                .filter(|(_stake_key, reg)| reg.stake > stake_threshold)
+                .fold(
+                    HashMap::new(),
+                    |mut acc,
+                     (
+                        _stake,
+                        CatalystRegistration {
+                            stake,
+                            reward_addr,
+                            voting_pub_key,
+                        },
+                    )| {
+                        acc.entry(voting_pub_key)
+                            .or_default()
+                            .push((reward_addr, stake));
+                        acc
+                    },
+                ),
+            stake_threshold,
+        }
+    }
+
+    pub fn stake_threshold(&self) -> Stake {
+        self.stake_threshold
+    }
+
+    pub fn to_block0_initials(&self, discrimination: Discrimination) -> Initial {
+        Initial::Fund(
+            self.inner
+                .iter()
+                .map(|(vk, regs)| {
+                    let value: Value = regs
+                        .iter()
+                        .map(|(_, stake)| u64::from(*stake))
+                        .sum::<u64>()
+                        .into();
+                    let address: Address =
+                        chain_addr::Address(discrimination, Kind::Account(vk.to_inner().into()))
+                            .into();
+                    InitialUTxO { address, value }
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    pub fn voting_keys(&self) -> Vec<Identifier> {
+        self.inner.keys().cloned().collect()
+    }
+
+    pub fn registrations_for_voting_key<I: Into<Identifier>>(
+        &self,
+        voting_pub_key: I,
+    ) -> Vec<CatalystRegistration> {
+        let voting_pub_key: Identifier = voting_pub_key.into();
+        self.inner
+            .get(&voting_pub_key)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(reward_addr, stake)| CatalystRegistration {
+                reward_addr,
+                stake,
+                voting_pub_key: voting_pub_key.clone(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_crypto::{Ed25519, SecretKey};
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for RawSnapshot {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let n_registrations = usize::arbitrary(g);
+
+            let mut raw_snapshot = HashMap::new();
+
+            for i in 0..n_registrations {
+                let stake_key = String::arbitrary(g);
+                let reward_addr = String::arbitrary(g);
+                let voting_pub_key = <SecretKey<Ed25519>>::arbitrary(g).to_public().into();
+                let stake: Stake = u64::arbitrary(g).into();
+                raw_snapshot.insert(
+                    stake_key,
+                    CatalystRegistration {
+                        stake,
+                        reward_addr,
+                        voting_pub_key,
+                    },
+                );
+            }
+
+            Self(raw_snapshot)
+        }
+    }
+
+    impl Arbitrary for Snapshot {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self::from_raw_snapshot(<_>::arbitrary(g), (u64::arbitrary(g)).into())
+        }
+    }
+
+    impl From<HashMap<MainnetStakeAddress, CatalystRegistration>> for RawSnapshot {
+        fn from(from: HashMap<MainnetStakeAddress, CatalystRegistration>) -> Self {
+            Self(from)
+        }
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4,6 +4,7 @@ use chain_addr::{Discrimination, Kind};
 use jormungandr_lib::crypto::account::Identifier;
 use jormungandr_lib::interfaces::{Address, Initial, InitialUTxO, Stake, Value};
 use serde::{de::Error, Deserialize, Deserializer};
+use std::iter::Iterator;
 
 pub type MainnetRewardAddress = String;
 pub type MainnetStakeAddress = String;
@@ -68,8 +69,8 @@ impl Snapshot {
         )
     }
 
-    pub fn voting_keys(&self) -> Vec<Identifier> {
-        self.inner.keys().cloned().collect()
+    pub fn voting_keys(&self) -> impl Iterator<Item = &Identifier> {
+        self.inner.keys()
     }
 
     pub fn registrations_for_voting_key<I: Into<Identifier>>(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,14 @@
 pub mod csv;
 pub mod serde;
+
+use rust_decimal::Decimal;
+
+const DEFAULT_DECIMAL_PRECISION: u32 = 10;
+
+#[track_caller]
+pub fn assert_are_close(a: Decimal, b: Decimal) {
+    assert_eq!(
+        a.round_dp(DEFAULT_DECIMAL_PRECISION),
+        b.round_dp(DEFAULT_DECIMAL_PRECISION)
+    );
+}


### PR DESCRIPTION
This PR does the following:
* port https://github.com/input-output-hk/catalyst-toolbox/pull/75 to fund 7 branch
* ignore inactive voters from the count of total stake for the purpose of rewards
* map the rewards back to mainnet addresses (snapshot parsing not yet tested)
* introduce support for new snapshot in catalyst-toolbox