### PR TITLE
Add active voter stats from vote count

### DIFF
--- a/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -90,7 +90,6 @@ impl VotersRewards {
             entry.sort_by_key(|p| p.voteplan.chain_proposal_index);
             acc
         });
-
         let vote_count = serde_json::from_reader::<_, HashMap<Identifier, Vec<AccountVotes>>>(
             jcli_lib::utils::io::open_file_read(&Some(votes_count_path))?,
         )?

--- a/catalyst-toolbox/src/bin/cli/stats/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/mod.rs
@@ -8,11 +8,11 @@ use color_eyre::Report;
 use live::LiveStatsCommand;
 use snapshot::SnapshotCommand;
 use structopt::StructOpt;
-use voters::InitialVotersCommand;
+use voters::VotersCommand;
 
 #[derive(StructOpt, Debug)]
 pub enum Stats {
-    Voters(InitialVotersCommand),
+    Voters(VotersCommand),
     Live(LiveStatsCommand),
     Archive(ArchiveCommand),
     Snapshot(SnapshotCommand),

--- a/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
@@ -1,3 +1,4 @@
+use catalyst_toolbox::stats::distribution::Stats;
 use catalyst_toolbox::stats::snapshot::read_initials;
 use catalyst_toolbox::stats::voters::calculate_wallet_distribution_from_initials;
 use color_eyre::Report;
@@ -28,17 +29,19 @@ impl SnapshotCommand {
 
         match self.command {
             Command::Count => calculate_wallet_distribution_from_initials(
+                Stats::new(self.threshold),
                 initials,
                 vec![],
-                self.threshold,
                 self.support_lovelace,
+                |stats, _, _| stats.add(1),
             )?
             .print_count_per_level(),
             Command::Ada => calculate_wallet_distribution_from_initials(
+                Stats::new(self.threshold),
                 initials,
                 vec![],
-                self.threshold,
                 self.support_lovelace,
+                |stats, value, _| stats.add(value),
             )?
             .print_ada_per_level(),
         };

--- a/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
@@ -29,7 +29,7 @@ impl SnapshotCommand {
 
         match self.command {
             Command::Count => calculate_wallet_distribution_from_initials(
-                Stats::new(self.threshold),
+                Stats::new(self.threshold)?,
                 initials,
                 vec![],
                 self.support_lovelace,
@@ -37,7 +37,7 @@ impl SnapshotCommand {
             )?
             .print_count_per_level(),
             Command::Ada => calculate_wallet_distribution_from_initials(
-                Stats::new(self.threshold),
+                Stats::new(self.threshold)?,
                 initials,
                 vec![],
                 self.support_lovelace,

--- a/catalyst-toolbox/src/bin/cli/stats/voters/active.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/active.rs
@@ -1,0 +1,73 @@
+use catalyst_toolbox::stats::distribution::Stats;
+use catalyst_toolbox::stats::voters::calculate_active_wallet_distribution;
+use std::ops::Range;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct ActiveVotersCommand {
+    #[structopt(long = "support-lovelace")]
+    pub support_lovelace: bool,
+    #[structopt(long = "block0")]
+    pub block0: String,
+    #[structopt(long = "threshold")]
+    pub threshold: u64,
+    #[structopt(long = "votes-count-file")]
+    pub votes_count_path: PathBuf,
+    #[structopt(subcommand)]
+    pub command: Command,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum Command {
+    Count,
+    Ada,
+    Votes,
+}
+
+impl ActiveVotersCommand {
+    pub fn exec(&self) -> Result<(), catalyst_toolbox::stats::Error> {
+        match self.command {
+            Command::Count => calculate_active_wallet_distribution(
+                Stats::new(self.threshold),
+                &self.block0,
+                &self.votes_count_path,
+                self.support_lovelace,
+                |stats, value, _| stats.add(value),
+            )?
+            .print_count_per_level(),
+            Command::Ada => calculate_active_wallet_distribution(
+                Stats::new(self.threshold),
+                &self.block0,
+                &self.votes_count_path,
+                self.support_lovelace,
+                |stats, value, _| stats.add(value),
+            )?
+            .print_ada_per_level(),
+            Command::Votes => calculate_active_wallet_distribution(
+                Stats::new_with_levels(casted_votes_levels()),
+                &self.block0,
+                &self.votes_count_path,
+                self.support_lovelace,
+                |stats, _, weight| stats.add_with_weight(1, weight as u32),
+            )?
+            .print_count_per_level(),
+        };
+
+        Ok(())
+    }
+}
+
+fn casted_votes_levels() -> Vec<Range<u64>> {
+    vec![
+        (1..5),
+        (5..10),
+        (10..20),
+        (20..50),
+        (50..100),
+        (100..200),
+        (200..400),
+        (400..800),
+        (800..5_000),
+    ]
+}

--- a/catalyst-toolbox/src/bin/cli/stats/voters/active.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/active.rs
@@ -1,5 +1,6 @@
 use catalyst_toolbox::stats::distribution::Stats;
 use catalyst_toolbox::stats::voters::calculate_active_wallet_distribution;
+use color_eyre::Report;
 use std::ops::Range;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -26,7 +27,7 @@ pub enum Command {
 }
 
 impl ActiveVotersCommand {
-    pub fn exec(&self) -> Result<(), catalyst_toolbox::stats::Error> {
+    pub fn exec(&self) -> Result<(), Report> {
         match self.command {
             Command::Count => calculate_active_wallet_distribution(
                 Stats::new(self.threshold),

--- a/catalyst-toolbox/src/bin/cli/stats/voters/initials.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/initials.rs
@@ -26,14 +26,14 @@ impl InitialVotersCommand {
         match self.command {
             Command::Count => calculate_wallet_distribution(
                 &self.block0,
-                Stats::new(self.threshold),
+                Stats::new(self.threshold)?,
                 self.support_lovelace,
                 |stats, value, _| stats.add(value),
             )?
             .print_count_per_level(),
             Command::Ada => calculate_wallet_distribution(
                 &self.block0,
-                Stats::new(self.threshold),
+                Stats::new(self.threshold)?,
                 self.support_lovelace,
                 |stats, value, _| stats.add(value),
             )?

--- a/catalyst-toolbox/src/bin/cli/stats/voters/initials.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/initials.rs
@@ -1,3 +1,4 @@
+use catalyst_toolbox::stats::distribution::Stats;
 use catalyst_toolbox::stats::voters::calculate_wallet_distribution;
 use color_eyre::Report;
 use structopt::StructOpt;
@@ -23,14 +24,20 @@ pub enum Command {
 impl InitialVotersCommand {
     pub fn exec(&self) -> Result<(), Report> {
         match self.command {
-            Command::Count => {
-                calculate_wallet_distribution(&self.block0, self.threshold, self.support_lovelace)?
-                    .print_count_per_level()
-            }
-            Command::Ada => {
-                calculate_wallet_distribution(&self.block0, self.threshold, self.support_lovelace)?
-                    .print_ada_per_level()
-            }
+            Command::Count => calculate_wallet_distribution(
+                &self.block0,
+                Stats::new(self.threshold),
+                self.support_lovelace,
+                |stats, value, _| stats.add(value),
+            )?
+            .print_count_per_level(),
+            Command::Ada => calculate_wallet_distribution(
+                &self.block0,
+                Stats::new(self.threshold),
+                self.support_lovelace,
+                |stats, value, _| stats.add(value),
+            )?
+            .print_ada_per_level(),
         };
 
         Ok(())

--- a/catalyst-toolbox/src/bin/cli/stats/voters/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/mod.rs
@@ -1,0 +1,21 @@
+mod active;
+mod initials;
+
+use active::ActiveVotersCommand;
+use initials::InitialVotersCommand;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum VotersCommand {
+    Initials(InitialVotersCommand),
+    Active(ActiveVotersCommand),
+}
+
+impl VotersCommand {
+    pub fn exec(self) -> Result<(), catalyst_toolbox::stats::Error> {
+        match self {
+            Self::Initials(initials) => initials.exec(),
+            Self::Active(active) => active.exec(),
+        }
+    }
+}

--- a/catalyst-toolbox/src/bin/cli/stats/voters/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/voters/mod.rs
@@ -2,6 +2,7 @@ mod active;
 mod initials;
 
 use active::ActiveVotersCommand;
+use color_eyre::Report;
 use initials::InitialVotersCommand;
 use structopt::StructOpt;
 
@@ -12,7 +13,7 @@ pub enum VotersCommand {
 }
 
 impl VotersCommand {
-    pub fn exec(self) -> Result<(), catalyst_toolbox::stats::Error> {
+    pub fn exec(self) -> Result<(), Report> {
         match self {
             Self::Initials(initials) => initials.exec(),
             Self::Active(active) => active.exec(),

--- a/catalyst-toolbox/src/recovery/tally.rs
+++ b/catalyst-toolbox/src/recovery/tally.rs
@@ -1,7 +1,6 @@
 use chain_addr::{Discrimination, Kind};
 use chain_core::property::Fragment as _;
 use chain_crypto::{Ed25519Extended, SecretKey};
-use chain_impl_mockchain::accounting::account::SpendingCounterIncreasing;
 use chain_impl_mockchain::{
     account::{self, LedgerError, SpendingCounter},
     block::{Block, BlockDate, HeaderId},
@@ -464,11 +463,8 @@ impl FragmentReplayer {
                         value: utxo.value,
                     };
                     wallet
-                        .set_state(
-                            utxo.value.into(),
-                            SpendingCounterIncreasing::default().get_valid_counters(),
-                        )
-                        .unwrap();
+                        .set_state(utxo.value.into(), Default::default())
+                        .expect("cannot update wallet state");
                     wallets.insert(utxo.address.clone(), wallet);
                     if committee_members.contains(&utxo.address) {
                         trace!("Committee account found {}", &utxo.address);

--- a/catalyst-toolbox/src/recovery/tally.rs
+++ b/catalyst-toolbox/src/recovery/tally.rs
@@ -3,6 +3,7 @@ use chain_core::property::Fragment as _;
 use chain_crypto::{Ed25519Extended, SecretKey};
 use chain_impl_mockchain::{
     account::{self, LedgerError, SpendingCounter},
+    accounting::account::SpendingCounterIncreasing,
     block::{Block, BlockDate, HeaderId},
     certificate::{self, VoteCast, VotePlan, VotePlanId},
     chaineval::ConsensusEvalContext,
@@ -463,7 +464,10 @@ impl FragmentReplayer {
                         value: utxo.value,
                     };
                     wallet
-                        .set_state(utxo.value.into(), Default::default())
+                        .set_state(
+                            utxo.value.into(),
+                            SpendingCounterIncreasing::default().get_valid_counters(),
+                        )
                         .expect("cannot update wallet state");
                     wallets.insert(utxo.address.clone(), wallet);
                     if committee_members.contains(&utxo.address) {

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -1,8 +1,9 @@
-use crate::snapshot::{registration::MainnetRewardAddress, SnapshotInfo};
-use jormungandr_lib::crypto::{account::Identifier, hash::Hash};
 use chain_addr::{Discrimination, Kind};
 use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
-use jormungandr_lib::{crypto::account::Identifier, interfaces::Address};
+use jormungandr_lib::{
+    crypto::{account::Identifier, hash::Hash},
+    interfaces::Address,
+};
 use rust_decimal::Decimal;
 use snapshot_lib::{registration::MainnetRewardAddress, SnapshotInfo};
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -108,6 +108,24 @@ fn filter_active_addresses(
         .collect()
 }
 
+pub fn account_hex_to_address(
+    account_hex: String,
+    discrimination: Discrimination,
+) -> Result<Address, hex::FromHexError> {
+    let mut buffer = [0u8; 32];
+    hex::decode_to_slice(account_hex, &mut buffer)?;
+    let identifier: UnspecifiedAccountIdentifier = UnspecifiedAccountIdentifier::from(buffer);
+    Ok(Address::from(chain_addr::Address(
+        discrimination,
+        Kind::Account(
+            identifier
+                .to_single_account()
+                .expect("Only single accounts are supported")
+                .into(),
+        ),
+    )))
+}
+
 fn rewards_to_mainnet_addresses(
     rewards: HashMap<Identifier, Rewards>,
     voters: Vec<SnapshotInfo>,

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -1,4 +1,8 @@
+use crate::snapshot::{registration::MainnetRewardAddress, SnapshotInfo};
 use jormungandr_lib::crypto::{account::Identifier, hash::Hash};
+use chain_addr::{Discrimination, Kind};
+use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
+use jormungandr_lib::{crypto::account::Identifier, interfaces::Address};
 use rust_decimal::Decimal;
 use snapshot_lib::{registration::MainnetRewardAddress, SnapshotInfo};
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/catalyst-toolbox/src/stats/distribution.rs
+++ b/catalyst-toolbox/src/stats/distribution.rs
@@ -5,7 +5,7 @@ fn levels(threshold: u64) -> Vec<Range<u64>> {
     vec![
         (0..450),
         (450..threshold),
-        (500..1_000),
+        (threshold..1_000),
         (1_000..2_000),
         (2_000..5_000),
         (5_000..10_000),
@@ -98,7 +98,9 @@ impl Stats {
 }
 
 fn format_big_number(n: u64) -> String {
-    if n % 1_000_000_000 == 0 {
+    if n == 0 {
+        n.to_string()
+    } else if n % 1_000_000_000 == 0 {
         format!("{} MLD", n / 1_000_000)
     } else if n % 1_00000 == 0 {
         format!("{} M", n / 1_000_000)

--- a/catalyst-toolbox/src/stats/distribution.rs
+++ b/catalyst-toolbox/src/stats/distribution.rs
@@ -3,8 +3,12 @@ use std::collections::HashMap;
 
 fn levels(threshold: u64) -> Vec<Range<u64>> {
     vec![
-        (0..threshold),
-        (threshold..10_000),
+        (0..450),
+        (450..threshold),
+        (500..1_000),
+        (1_000..2_000),
+        (2_000..5_000),
+        (5_000..10_000),
         (10_000..20_000),
         (20_000..50_000),
         (50_000..100_000),
@@ -31,22 +35,30 @@ pub struct Stats {
 
 impl Stats {
     pub fn new(threshold: u64) -> Self {
+        Self::new_with_levels(levels(threshold))
+    }
+
+    pub fn new_with_levels(levels: Vec<Range<u64>>) -> Self {
         Self {
-            content: levels(threshold)
+            content: levels
                 .into_iter()
                 .map(|range| (range, Default::default()))
                 .collect(),
         }
     }
 
-    pub fn add(&mut self, value: u64) {
+    pub fn add_with_weight(&mut self, value: u64, weight: u32) {
         for (range, record) in self.content.iter_mut() {
             if range.contains(&value) {
-                record.count += 1;
+                record.count += weight;
                 record.total += value;
                 return;
             }
         }
+    }
+
+    pub fn add(&mut self, value: u64) {
+        self.add_with_weight(value, 1);
     }
 
     pub fn print_count_per_level(&self) {

--- a/catalyst-toolbox/src/stats/distribution.rs
+++ b/catalyst-toolbox/src/stats/distribution.rs
@@ -1,8 +1,13 @@
 use core::ops::Range;
 use std::collections::HashMap;
+use thiserror::Error;
 
-fn levels(threshold: u64) -> Vec<Range<u64>> {
-    vec![
+fn levels(threshold: u64) -> Result<Vec<Range<u64>>, Error> {
+    if !(450..=1_000).contains(&threshold) {
+        return Err(Error::InvalidThreshold(threshold));
+    }
+
+    Ok(vec![
         (0..450),
         (450..threshold),
         (threshold..1_000),
@@ -20,7 +25,7 @@ fn levels(threshold: u64) -> Vec<Range<u64>> {
         (10_000_000..25_000_000),
         (25_000_000..50_000_000),
         (50_000_000..32_000_000_000),
-    ]
+    ])
 }
 
 #[derive(Default)]
@@ -34,8 +39,8 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new(threshold: u64) -> Self {
-        Self::new_with_levels(levels(threshold))
+    pub fn new(threshold: u64) -> Result<Self, Error> {
+        Ok(Self::new_with_levels(levels(threshold)?))
     }
 
     pub fn new_with_levels(levels: Vec<Range<u64>>) -> Self {
@@ -109,4 +114,11 @@ fn format_big_number(n: u64) -> String {
     } else {
         n.to_string()
     }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid threshold for distribution levels ({0}). It should be more than 450 and less that 1000")]
+    InvalidThreshold(u64),
 }

--- a/catalyst-toolbox/src/stats/voters.rs
+++ b/catalyst-toolbox/src/stats/voters.rs
@@ -45,8 +45,8 @@ fn vote_counts_as_utxo(
         .filter_map(|initials| {
             if let Initial::Fund(funds) = initials {
                 for utxo in funds {
-                    if let Some(vote_count) = votes_count.get(&addr_to_hex(&utxo.address)) {
-                        return Some((utxo.clone(), *vote_count as u32));
+                    if let Some(hash_set) = votes_count.get(&addr_to_id(&utxo.address)) {
+                        return Some((utxo.clone(), hash_set.len() as u32));
                     }
                 }
             }
@@ -55,12 +55,9 @@ fn vote_counts_as_utxo(
         .collect()
 }
 
-pub fn addr_to_hex(address: &Address) -> String {
+pub fn addr_to_id(address: &Address) -> Identifier {
     match &address.1 .1 {
-        Kind::Account(pk) => {
-            let id: Identifier = pk.clone().into();
-            id.to_hex()
-        }
+        Kind::Account(pk) => pk.clone().into(),
         _ => unimplemented!(),
     }
 }

--- a/catalyst-toolbox/src/stats/voters.rs
+++ b/catalyst-toolbox/src/stats/voters.rs
@@ -13,7 +13,6 @@ use std::path::Path;
 fn blacklist_addresses(genesis: &Block0Configuration) -> Vec<Address> {
     let discrimination = genesis.blockchain_configuration.discrimination;
 
-    #[allow(clippy::needless_collect)]
     genesis
         .blockchain_configuration
         .committees
@@ -40,12 +39,13 @@ fn vote_counts_as_addresses(
     votes_count: VoteCount,
     genesis: &Block0Configuration,
 ) -> Vec<(InitialUTxO, u32)> {
-    votes_count
+    genesis
+        .initial
         .iter()
-        .filter_map(|(address, votes_count)| {
-            for initials in &genesis.initial {
-                if let Initial::Fund(funds) = initials {
-                    if let Some(utxo) = funds.iter().find(|utxo| {
+        .filter_map(|initials| {
+            if let Initial::Fund(funds) = initials {
+                for utxo in funds {
+                    if let Some((_, votes_count)) = votes_count.iter().find(|(address, _)| {
                         account_hex_to_address(
                             address.to_string(),
                             genesis.blockchain_configuration.discrimination,

--- a/catalyst-toolbox/tests/tally/generator.rs
+++ b/catalyst-toolbox/tests/tally/generator.rs
@@ -45,7 +45,7 @@ fn account_from_slice<P>(
     }
 }
 
-impl<'a> VoteRoundGenerator {
+impl VoteRoundGenerator {
     pub fn new(blockchain: TestBlockchain) -> Self {
         let TestBlockchain {
             config,


### PR DESCRIPTION
This PR is implementation for requests from Research team for additional stats:

Request 1:

```
Could we expand following levels please - I was asked if we can be more granular on small.

450-500
[500-1000]
[1000-200]
[2000-5000]
[5000-10000]
```

Request 2: 

```
is there a way to find out how many individual votes were cast per wallet basis?
we are trying to establish how many votes do different sized wallets tend to cast
do bigger whales care more about proposals
do smaller wallets cast more votes - or if there is no correlation
```

Request 3:
```
Are we able to parse data based on votes cast range?
Meaning number of wallets with a-b votes cast something like this
1-5
5-10
10-20
20-50
50-100
100-200
200-400
400-800
800+

So above is total votes cast - and how many wallets did that
```