### PR TITLE
Add voting power cap during snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "color-eyre",
  "csv",
  "env_logger 0.9.0",
+ "fraction",
  "futures",
  "gag",
  "graphql_client",
@@ -631,7 +632,7 @@ dependencies = [
  "imhamt",
  "libsecp256k1",
  "logos",
- "num",
+ "num 0.4.0",
  "quickcheck",
  "ripemd",
  "rlp",
@@ -1668,6 +1669,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb65943183b6b3cbf00f64c181e8178217e30194381b150e4f87ec59864c803"
+dependencies = [
+ "lazy_static",
+ "num 0.2.1",
 ]
 
 [[package]]
@@ -3135,15 +3146,40 @@ dependencies = [
 
 [[package]]
 name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint",
- "num-complex",
+ "num-bigint 0.4.3",
+ "num-complex 0.4.0",
  "num-integer",
  "num-iter",
  "num-rational 0.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3155,6 +3191,16 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
@@ -3201,6 +3247,18 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
@@ -3217,7 +3275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -5630,7 +5688,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 name = "voting-hir"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "jormungandr-lib",
+ "proptest 1.0.0 (git+https://github.com/input-output-hk/proptest?branch=master)",
  "serde",
 ]
 

--- a/catalyst-toolbox/Cargo.toml
+++ b/catalyst-toolbox/Cargo.toml
@@ -56,11 +56,12 @@ image = "0.23.12"
 qrcode = "0.12"
 quircs = "0.10.0"
 symmetric-cipher = { git = "https://github.com/input-output-hk/chain-wallet-libs.git", branch = "master" }
-graphql_client = "0.10"
+graphql_client = { version = "0.10" }
 gag = "1"
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "master" }
 env_logger = "0.9"
 voting-hir = { path = "../voting-hir", features = ["serde"] }
+fraction = "*"
 
 [dev-dependencies]
 rand_chacha = "0.3"
@@ -71,6 +72,7 @@ chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch
 proptest = { git = "https://github.com/input-output-hk/proptest", branch = "master" }
 test-strategy = "0.2"
 serde_test = "1"
+voting-hir =  { path = "../voting-hir", features = ["serde", "proptest"] }
 
 [build-dependencies]
 versionisator = "1.0.3"

--- a/catalyst-toolbox/Cargo.toml
+++ b/catalyst-toolbox/Cargo.toml
@@ -56,12 +56,12 @@ image = "0.23.12"
 qrcode = "0.12"
 quircs = "0.10.0"
 symmetric-cipher = { git = "https://github.com/input-output-hk/chain-wallet-libs.git", branch = "master" }
-graphql_client = { version = "0.10" }
+graphql_client = "0.10"
 gag = "1"
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "master" }
 env_logger = "0.9"
 voting-hir = { path = "../voting-hir", features = ["serde"] }
-fraction = "*"
+fraction = "0.10"
 
 [dev-dependencies]
 rand_chacha = "0.3"

--- a/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -5,9 +5,9 @@ use catalyst_toolbox::snapshot::{
 use catalyst_toolbox::utils::assert_are_close;
 
 use color_eyre::Report;
+use fraction::Fraction;
 use jcli_lib::jcli_lib::block::Common;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::Block0Configuration};
-
 use structopt::StructOpt;
 
 use std::collections::BTreeMap;

--- a/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -1,10 +1,12 @@
 use catalyst_toolbox::rewards::voters::{calc_voter_rewards, Rewards, VoteCount};
-use catalyst_toolbox::snapshot::{registration::MainnetRewardAddress, Snapshot};
+use catalyst_toolbox::snapshot::{
+    registration::MainnetRewardAddress, voting_group::VotingGroupAssigner, Snapshot,
+};
 use catalyst_toolbox::utils::assert_are_close;
 
 use color_eyre::Report;
 use jcli_lib::jcli_lib::block::Common;
-use jormungandr_lib::interfaces::Block0Configuration;
+use jormungandr_lib::{crypto::account::Identifier, interfaces::Block0Configuration};
 
 use structopt::StructOpt;
 
@@ -29,6 +31,10 @@ pub struct VotersRewards {
     /// will be ignored
     #[structopt(long)]
     registration_threshold: u64,
+
+    /// Voting power cap for each account
+    #[structopt(short, long)]
+    voting_power_cap: Fraction,
 
     #[structopt(long)]
     votes_count_path: PathBuf,
@@ -64,6 +70,7 @@ impl VotersRewards {
             registration_threshold,
             votes_count_path,
             vote_threshold,
+            voting_power_cap,
         } = self;
         let block = common.input.load_block()?;
         let block0 = Block0Configuration::from_block(&block)?;
@@ -75,7 +82,9 @@ impl VotersRewards {
         let snapshot = Snapshot::from_raw_snapshot(
             serde_json::from_reader(jcli_lib::utils::io::open_file_read(&Some(snapshot_path))?)?,
             registration_threshold.into(),
-        );
+            voting_power_cap,
+            &DummyAssigner,
+        )?;
 
         let results = calc_voter_rewards(
             vote_count,
@@ -90,5 +99,12 @@ impl VotersRewards {
 
         write_rewards_results(common, &results)?;
         Ok(())
+    }
+}
+
+struct DummyAssigner;
+impl VotingGroupAssigner for DummyAssigner {
+    fn assign(&self, _vk: &Identifier) -> String {
+        unimplemented!()
     }
 }

--- a/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -20,10 +20,7 @@ pub struct SnapshotCmd {
     snapshot: PathBuf,
     /// Registrations voting power threshold for eligibility
     #[structopt(short, long)]
-    min_stake_threshold: Value,
-    /// Maximum stake in percent that could be controlled by a single entity
-    /// in the resulting HIR
-    max_stake_percent: Option<Decimal>,
+    threshold: Value,
 
     /// Voter group to assign direct voters to.
     /// If empty, defaults to "voter"

--- a/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -1,5 +1,6 @@
 use catalyst_toolbox::snapshot::{voting_group::RepsVotersAssigner, RawSnapshot, Snapshot};
 use color_eyre::Report;
+use fraction::Fraction;
 use jcli_lib::utils::{output_file::OutputFile, output_format::OutputFormat};
 use jormungandr_lib::interfaces::Value;
 use std::fs::File;

--- a/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -2,12 +2,13 @@ use catalyst_toolbox::snapshot::{voting_group::RepsVotersAssigner, RawSnapshot, 
 use color_eyre::Report;
 use jcli_lib::utils::{output_file::OutputFile, output_format::OutputFormat};
 use jormungandr_lib::interfaces::Value;
+use rust_decimal::Decimal;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-const DEFAULT_DIRECT_VOTER_GROUP: &str = "voter";
+const DEFAULT_DIRECT_VOTER_GROUP: &str = "direct";
 const DEFAULT_REPRESENTATIVE_GROUP: &str = "rep";
 
 /// Process raw registrations into blockchain initials
@@ -19,7 +20,10 @@ pub struct SnapshotCmd {
     snapshot: PathBuf,
     /// Registrations voting power threshold for eligibility
     #[structopt(short, long)]
-    threshold: Value,
+    min_stake_threshold: Value,
+    /// Maximum stake in percent that could be controlled by a single entity
+    /// in the resulting HIR
+    max_stake_percent: Option<Decimal>,
 
     /// Voter group to assign direct voters to.
     /// If empty, defaults to "voter"

--- a/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -2,7 +2,6 @@ use catalyst_toolbox::snapshot::{voting_group::RepsVotersAssigner, RawSnapshot, 
 use color_eyre::Report;
 use jcli_lib::utils::{output_file::OutputFile, output_format::OutputFormat};
 use jormungandr_lib::interfaces::Value;
-use rust_decimal::Decimal;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -36,6 +35,10 @@ pub struct SnapshotCmd {
     #[structopt(long)]
     reps_db_api_url: reqwest::Url,
 
+    /// Voting power cap for each account
+    #[structopt(short, long)]
+    voting_power_cap: Fraction,
+
     #[structopt(flatten)]
     output: OutputFile,
 
@@ -53,8 +56,13 @@ impl SnapshotCmd {
             .representatives_group
             .unwrap_or_else(|| DEFAULT_REPRESENTATIVE_GROUP.into());
         let assigner = RepsVotersAssigner::new(direct_voter, representative, self.reps_db_api_url)?;
-        let initials =
-            Snapshot::from_raw_snapshot(raw_snapshot, self.threshold).to_voter_hir(&assigner);
+        let initials = Snapshot::from_raw_snapshot(
+            raw_snapshot,
+            self.threshold,
+            self.voting_power_cap,
+            &assigner,
+        )?
+        .to_voter_hir();
         let mut out_writer = self.output.open()?;
         let content = self
             .output_format

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -186,6 +186,7 @@ mod tests {
     use chain_impl_mockchain::chaintypes::ConsensusVersion;
     use chain_impl_mockchain::fee::LinearFee;
     use chain_impl_mockchain::tokens::{identifier::TokenIdentifier, name::TokenName};
+    use fraction::Fraction;
     use jormungandr_lib::crypto::account::Identifier;
     use jormungandr_lib::interfaces::BlockchainConfiguration;
     use jormungandr_lib::interfaces::{Destination, Initial, InitialToken, InitialUTxO};
@@ -338,7 +339,13 @@ mod tests {
             total_stake += i;
         }
 
-        let snapshot = Snapshot::from_raw_snapshot(raw_snapshot.into(), 0.into());
+        let snapshot = Snapshot::from_raw_snapshot(
+            raw_snapshot.into(),
+            0.into(),
+            Fraction::from(1u64),
+            &|_vk: &Identifier| String::new(),
+        )
+        .unwrap();
 
         let initial = snapshot.to_block0_initials(Discrimination::Test);
         let block0 = blockchain_configuration(initial);

--- a/catalyst-toolbox/src/snapshot/influence_cap.rs
+++ b/catalyst-toolbox/src/snapshot/influence_cap.rs
@@ -15,7 +15,7 @@ fn int_ceil(a: u64, b: u64) -> u64 {
 /// The solution to this equation is therefore Y <= (X - T*TOT) / (1 - T).
 /// Since we work with integer numbers, we will use Y' = ceil(Y).
 ///
-/// Panics if threshold is >= 1 or x/tot <= threshold
+/// Panics if threshold is > 1 or x/tot <= threshold
 fn calc_vp_to_remove(x: u64, tot: u64, threshold: Fraction) -> u64 {
     assert!(threshold <= Fraction::from(1u64));
     assert!(threshold < Fraction::new(x, tot));

--- a/catalyst-toolbox/src/snapshot/influence_cap.rs
+++ b/catalyst-toolbox/src/snapshot/influence_cap.rs
@@ -1,0 +1,200 @@
+use super::{Error, VoterEntry};
+use fraction::{BigFraction, Fraction};
+use rust_decimal::prelude::ToPrimitive;
+
+/// Calculates ceil(a / b) where a and b are integers with perfect precision
+#[inline]
+fn int_ceil(a: u64, b: u64) -> u64 {
+    assert!(b > 0);
+    (a + b - 1) / b
+}
+
+/// Let's denote with X the current voting power of user U and with TOT the total voting power
+/// and suppose X / TOT >= threshold.
+/// We want to remove a quantity Y from X such that (X - Y)/ (TOT - Y) <= treshold.
+/// The solution to this equation is therefore Y <= (X - T*TOT) / (1 - T).
+/// Since we work with integer numbers, we will use Y' = ceil(Y).
+///
+/// Panics if threshold is >= 1 or x/tot <= threshold
+fn calc_vp_to_remove(x: u64, tot: u64, threshold: Fraction) -> u64 {
+    assert!(threshold <= Fraction::from(1u64));
+    assert!(threshold < Fraction::new(x, tot));
+    // Avoid cluttering this part with overflow checks by using big ints.
+    // The result is guaranteed to fit in a u64 anyway.
+    let threshold = BigFraction::from_fraction(threshold);
+    let num = BigFraction::from(x) - threshold.clone() * BigFraction::from(tot);
+    let denum = BigFraction::from(1u64) - threshold;
+    // Y must be smaller than X, hence it's safe to unwrap here
+    (num / denum).ceil().to_u64().unwrap()
+}
+
+/// Cap each individual voting power according to the threshold, if possible.
+///
+/// Obviously, to cap each individual's influence to T, we need at east M = ceil(1/T) participants.
+/// If we have M or more participants, it's always possible to do it.
+///
+/// The algorithm is as follows:
+/// 1. Sort the list of voters V = [V_0, ..., V_n] in non-decreasing order according to voting power Vp_i.
+/// 2. Let S be the set of contiguous voters being currently considered, X the voting power of each of the voters inside S,
+///   and V_l the leftmost voter inside S. All voters in S will be given the same voting power.
+///   Initially, set S = {V_n}, X = Vp_n.
+///   2.1 Calculate Y, how much voting power we should remove from each of the voters in S to match the
+///       threshold (see [calc_vp_to_remove] for more information).
+///       If (a) X - Y >= Vp_{l-1}, set X to X - Y. The current list is the solution.
+///       If (b) X - Y < Vp_{l-1}, set X to Vp_{l-1}, add V_{l-1} to S and repeat from step 2.1.
+///       It's easy to see we need to repeat step 2.1 at most min(ceil(1/T), N) times.
+///
+/// Complexity: O(NlogN + min(ceil(1/T), N))
+pub fn cap_voting_influence(
+    mut voters: Vec<VoterEntry>,
+    threshold: Fraction,
+) -> Result<Vec<VoterEntry>, Error> {
+    println!("n voters: {}", voters.len());
+    voters = voters
+        .into_iter()
+        .filter(|v| v.hir.voting_power > 0.into())
+        .collect();
+
+    if voters.is_empty() {
+        return Ok(voters);
+    }
+
+    if Fraction::new(1u64, voters.len() as u64) > threshold {
+        return Err(Error::NotEnoughVoters);
+    }
+    let mut tot = 0u64;
+    // can't check for overflows with Iterator::sum()
+    for v in &voters {
+        tot = tot
+            .checked_add(u64::from(v.hir.voting_power))
+            .ok_or(Error::Overflow)?;
+    }
+    voters.sort_unstable_by_key(|v| v.hir.voting_power);
+    let cur = voters.len() - 1;
+
+    let cur_vp = u64::from(voters[cur].hir.voting_power);
+    if Fraction::new(cur_vp, tot) <= threshold {
+        return Ok(voters);
+    }
+
+    let mut prev = cur - 1;
+    let mut next_vp = cur_vp;
+    let next_vp = loop {
+        let set_len = (cur - prev) as u64;
+        // Since it's guaranteed that all elements in S will have the same voting power,
+        // to calculate the value of Y for each element in S it's sufficient to treat it as a single
+        // value which should not exceed a threshold of T * |S| and get Y'.
+        // Given Y', we need to 'spread' it among all elements, from which we get Y = ceil(Y / len).
+        let y = int_ceil(
+            calc_vp_to_remove(next_vp * set_len, tot, threshold * set_len.into()),
+            set_len,
+        );
+        let prev_vp = u64::from(voters[prev].hir.voting_power);
+        if next_vp - y >= prev_vp {
+            // Case (a): we can fix the current voter without impacting other
+            next_vp -= y;
+            break next_vp;
+        } else {
+            // Case (b): we need to enlarge the set S and try again
+            tot -= (next_vp - prev_vp) * set_len;
+            next_vp = prev_vp;
+        }
+        assert!(prev > 0);
+        prev -= 1;
+    };
+
+    for v in &mut voters[prev + 1..=cur] {
+        v.hir.voting_power = next_vp.into();
+    }
+
+    Ok(voters)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{collection::vec, prelude::*};
+    use test_strategy::proptest;
+    use voting_hir::{proptest::VpRange, VoterHIR};
+
+    const DEFAULT_VP_STRATEGY: VpRange = VpRange::ada_distribution();
+
+    #[proptest]
+    fn test_insufficient_voters(
+        #[strategy(vec(any::<VoterEntry>(), 1..100))] voters: Vec<VoterEntry>,
+    ) {
+        let cap = Fraction::new(1u64, voters.len() as u64 + 1);
+        assert!(cap_voting_influence(voters, cap).is_err());
+    }
+
+    #[proptest]
+    fn test_exact_voters(
+        #[strategy(vec(any_with::<VoterEntry>((Default::default(), DEFAULT_VP_STRATEGY)), 1..100))]
+        voters: Vec<VoterEntry>,
+    ) {
+        let cap = Fraction::new(1u64, voters.len() as u64);
+        let min = voters.iter().map(|v| v.hir.voting_power).min().unwrap();
+        let res = cap_voting_influence(voters, cap).unwrap();
+        assert!(res
+            .iter()
+            .map(|entry| entry.hir.voting_power)
+            .all(|vp| vp == min));
+    }
+
+    #[proptest]
+    fn test_exact_voters_fixed_at_threshold(
+        #[strategy(vec(any_with::<VoterEntry>((Default::default(), DEFAULT_VP_STRATEGY)), 101..=101))]
+        voters: Vec<VoterEntry>,
+    ) {
+        let cap = Fraction::new(999u64, 100000u64);
+        let res = cap_voting_influence(voters, cap).unwrap();
+        let vps = res
+            .iter()
+            .map(|entry| u64::from(entry.hir.voting_power))
+            .collect::<Vec<_>>();
+        let tot = vps.iter().sum::<u64>();
+        for v in vps {
+            assert!(Fraction::new(v, tot) <= cap);
+        }
+    }
+
+    #[proptest]
+    fn test_exact_voters_fixed_below_threshold(
+        #[strategy(vec(any_with::<VoterEntry>((Default::default(), DEFAULT_VP_STRATEGY)), 100..=100))]
+        voters: Vec<VoterEntry>,
+    ) {
+        let cap = Fraction::new(9u64, 1000u64);
+        assert!(cap_voting_influence(voters, cap).is_err());
+    }
+
+    #[proptest]
+    fn test_below_threshold(
+        #[strategy(vec(any_with::<VoterEntry>((Default::default(), DEFAULT_VP_STRATEGY)), 100..300))]
+        voters: Vec<VoterEntry>,
+    ) {
+        let cap = Fraction::new(1u64, 100u64);
+        let res = cap_voting_influence(voters, cap).unwrap();
+        let vps = res
+            .iter()
+            .map(|entry| u64::from(entry.hir.voting_power))
+            .collect::<Vec<_>>();
+        let tot = vps.iter().sum::<u64>();
+        for v in vps {
+            assert!(Fraction::new(v, tot) <= cap);
+        }
+    }
+
+    impl Arbitrary for VoterEntry {
+        type Parameters = (String, VpRange);
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            any_with::<VoterHIR>(args)
+                .prop_map(|hir| Self {
+                    contributions: Vec::new(),
+                    hir,
+                })
+                .boxed()
+        }
+    }
+}

--- a/catalyst-toolbox/src/snapshot/mod.rs
+++ b/catalyst-toolbox/src/snapshot/mod.rs
@@ -1,12 +1,15 @@
+mod influence_cap;
 pub mod registration;
 pub mod voting_group;
 
 use registration::{Delegations, MainnetRewardAddress, VotingRegistration};
 use voting_group::VotingGroupAssigner;
 
+use fraction::Fraction;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::Value};
 use serde::Deserialize;
 use std::{borrow::Borrow, collections::BTreeMap, iter::Iterator, num::NonZeroU64};
+use thiserror::Error;
 use voting_hir::VoterHIR;
 
 pub const CATALYST_VOTING_PURPOSE_TAG: u64 = 0;
@@ -20,6 +23,14 @@ impl From<Vec<VotingRegistration>> for RawSnapshot {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("insufficient number of voters to guarantee voting influence cap")]
+    NotEnoughVoters,
+    #[error("voting power overflow")]
+    Overflow,
+}
+
 /// Contribution to a voting key for some registration
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyContribution {
@@ -28,87 +39,116 @@ pub struct KeyContribution {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct VoterEntry {
+    contributions: Vec<KeyContribution>,
+    hir: VoterHIR,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Snapshot {
     // a raw public key is preferred so that we don't have to worry about discrimination when deserializing from
     // a CIP-36 compatible encoding
-    inner: BTreeMap<Identifier, Vec<KeyContribution>>,
+    inner: BTreeMap<Identifier, VoterEntry>,
     stake_threshold: Value,
 }
 
 impl Snapshot {
-    pub fn from_raw_snapshot(raw_snapshot: RawSnapshot, stake_threshold: Value) -> Self {
-        Self {
-            inner: raw_snapshot
-                .0
-                .into_iter()
-                // Discard registrations with 0 voting power since they don't influence
-                // snapshot anyway
-                .filter(|reg| reg.voting_power >= std::cmp::max(stake_threshold, 1.into()))
-                // TODO: add capability to select voting purpose for a snapshot.
-                // At the moment Catalyst is the only one in use
-                .filter(|reg| reg.voting_purpose == CATALYST_VOTING_PURPOSE_TAG)
-                .fold(BTreeMap::new(), |mut acc, reg| {
-                    let VotingRegistration {
-                        reward_address,
-                        delegations,
-                        voting_power,
-                        ..
-                    } = reg;
+    pub fn from_raw_snapshot(
+        raw_snapshot: RawSnapshot,
+        stake_threshold: Value,
+        cap: Fraction,
+        voting_group_assigner: &impl VotingGroupAssigner,
+    ) -> Result<Self, Error> {
+        let raw_contribs = raw_snapshot
+            .0
+            .into_iter()
+            // Discard registrations with 0 voting power since they don't influence
+            // snapshot anyway
+            .filter(|reg| reg.voting_power >= std::cmp::max(stake_threshold, 1.into()))
+            // TODO: add capability to select voting purpose for a snapshot.
+            // At the moment Catalyst is the only one in use
+            .filter(|reg| reg.voting_purpose == CATALYST_VOTING_PURPOSE_TAG)
+            .fold(BTreeMap::new(), |mut acc: BTreeMap<_, Vec<_>>, reg| {
+                let VotingRegistration {
+                    reward_address,
+                    delegations,
+                    voting_power,
+                    ..
+                } = reg;
 
-                    match delegations {
-                        Delegations::Legacy(vk) => {
-                            acc.entry(vk).or_default().push(KeyContribution {
-                                reward_address,
-                                value: voting_power.into(),
-                            });
-                        }
-                        Delegations::New(mut vks) => {
-                            let voting_power = u64::from(voting_power);
-                            let total_weights =
-                                NonZeroU64::new(vks.iter().map(|(_, weight)| *weight as u64).sum());
+                match delegations {
+                    Delegations::Legacy(vk) => {
+                        acc.entry(vk).or_default().push(KeyContribution {
+                            reward_address,
+                            value: voting_power.into(),
+                        });
+                    }
+                    Delegations::New(mut vks) => {
+                        let voting_power = u64::from(voting_power);
+                        let total_weights =
+                            NonZeroU64::new(vks.iter().map(|(_, weight)| *weight as u64).sum());
 
-                            let last = vks.pop().expect("CIP36 requires at least 1 delegation");
-                            let others_total_vp = total_weights.map_or(0, |non_zero_total| {
-                                vks.into_iter()
-                                    .filter_map(|(vk, weight)| {
-                                        NonZeroU64::new(
-                                            (voting_power * weight as u64) / non_zero_total,
-                                        )
+                        let last = vks.pop().expect("CIP36 requires at least 1 delegation");
+                        let others_total_vp = total_weights.map_or(0, |non_zero_total| {
+                            vks.into_iter()
+                                .filter_map(|(vk, weight)| {
+                                    NonZeroU64::new((voting_power * weight as u64) / non_zero_total)
                                         .map(|value| (vk, value))
-                                    })
-                                    .map(|(vk, value)| {
-                                        acc.entry(vk).or_default().push(KeyContribution {
-                                            reward_address: reward_address.clone(),
-                                            value: value.get(),
-                                        });
-                                        value.get()
-                                    })
-                                    .sum::<u64>()
-                            });
-                            acc.entry(last.0).or_default().push(KeyContribution {
-                                reward_address,
-                                value: voting_power - others_total_vp,
-                            });
-                        }
-                    };
-                    acc
-                }),
+                                })
+                                .map(|(vk, value)| {
+                                    acc.entry(vk).or_default().push(KeyContribution {
+                                        reward_address: reward_address.clone(),
+                                        value: value.get(),
+                                    });
+                                    value.get()
+                                })
+                                .sum::<u64>()
+                        });
+                        acc.entry(last.0).or_default().push(KeyContribution {
+                            reward_address,
+                            value: voting_power - others_total_vp,
+                        });
+                    }
+                };
+                acc
+            });
+        let entries = raw_contribs
+            .into_iter()
+            .map(|(k, contributions)| VoterEntry {
+                hir: VoterHIR {
+                    voting_group: voting_group_assigner.assign(&k),
+                    voting_key: k,
+                    voting_power: contributions.iter().map(|c| c.value).sum::<u64>().into(),
+                },
+                contributions,
+            })
+            .collect();
+        Ok(Self {
+            inner: Self::apply_voting_power_cap(entries, cap)?
+                .into_iter()
+                .map(|entry| (entry.hir.voting_key.clone(), entry))
+                .collect(),
             stake_threshold,
-        }
+        })
+    }
+
+    fn apply_voting_power_cap(
+        voters: Vec<VoterEntry>,
+        cap: Fraction,
+    ) -> Result<Vec<VoterEntry>, Error> {
+        Ok(influence_cap::cap_voting_influence(voters, cap)?
+            .into_iter()
+            .collect())
     }
 
     pub fn stake_threshold(&self) -> Value {
         self.stake_threshold
     }
 
-    pub fn to_voter_hir(&self, voting_group_assigner: &impl VotingGroupAssigner) -> Vec<VoterHIR> {
+    pub fn to_voter_hir(&self) -> Vec<VoterHIR> {
         self.inner
-            .iter()
-            .map(|(voting_key, contribs)| VoterHIR {
-                voting_key: voting_key.clone(),
-                voting_power: contribs.iter().map(|c| c.value).sum::<u64>().into(),
-                voting_group: voting_group_assigner.assign(voting_key),
-            })
+            .values()
+            .map(|entry| entry.hir.clone())
             .collect::<Vec<_>>()
     }
 
@@ -123,6 +163,7 @@ impl Snapshot {
         self.inner
             .get(voting_public_key.borrow())
             .cloned()
+            .map(|entry| entry.contributions)
             .unwrap_or_default()
     }
 }
@@ -135,12 +176,20 @@ mod tests {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
+    struct DummyAssigner;
+
+    impl VotingGroupAssigner for DummyAssigner {
+        fn assign(&self, _vk: &Identifier) -> String {
+            String::new()
+        }
+    }
+
     impl Snapshot {
         pub fn to_block0_initials(&self, discrimination: Discrimination) -> Vec<InitialUTxO> {
             self.inner
                 .iter()
-                .map(|(vk, contribs)| {
-                    let value: Value = contribs.iter().map(|c| c.value).sum::<u64>().into();
+                .map(|(vk, entry)| {
+                    let value = entry.hir.voting_power;
                     let address: Address =
                         chain_addr::Address(discrimination, Kind::Account(vk.to_inner().into()))
                             .into();
@@ -164,8 +213,20 @@ mod tests {
         let mut add = raw.clone();
         add.0.push(additional_reg.clone());
         assert_eq!(
-            Snapshot::from_raw_snapshot(raw, stake_threshold.into())
-                == Snapshot::from_raw_snapshot(add, stake_threshold.into()),
+            Snapshot::from_raw_snapshot(
+                raw,
+                stake_threshold.into(),
+                Fraction::from(1u64),
+                &DummyAssigner
+            )
+            .unwrap()
+                == Snapshot::from_raw_snapshot(
+                    add,
+                    stake_threshold.into(),
+                    Fraction::from(1u64),
+                    &DummyAssigner
+                )
+                .unwrap(),
             additional_reg.voting_power < stake_threshold.into()
         );
     }
@@ -177,7 +238,13 @@ mod tests {
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             (any::<RawSnapshot>(), 1..u64::MAX)
                 .prop_map(|(raw_snapshot, threshold)| {
-                    Self::from_raw_snapshot(raw_snapshot, threshold.into())
+                    Self::from_raw_snapshot(
+                        raw_snapshot,
+                        threshold.into(),
+                        Fraction::from(1),
+                        &|_vk: &Identifier| String::new(),
+                    )
+                    .unwrap()
                 })
                 .boxed()
         }
@@ -186,9 +253,15 @@ mod tests {
     // Test all voting power is distributed among delegated keys
     #[proptest]
     fn test_voting_power_all_distributed(reg: VotingRegistration) {
-        let snapshot = Snapshot::from_raw_snapshot(vec![reg.clone()].into(), 0.into());
+        let snapshot = Snapshot::from_raw_snapshot(
+            vec![reg.clone()].into(),
+            0.into(),
+            Fraction::from(1),
+            &|_vk: &Identifier| String::new(),
+        )
+        .unwrap();
         let total_stake = snapshot
-            .to_voter_hir(&|_vk: &Identifier| String::new())
+            .to_voter_hir()
             .into_iter()
             .map(|hir| u64::from(hir.voting_power))
             .sum::<u64>();
@@ -199,8 +272,20 @@ mod tests {
     fn test_non_catalyst_regs_are_ignored(mut reg: VotingRegistration) {
         reg.voting_purpose = 1;
         assert_eq!(
-            Snapshot::from_raw_snapshot(vec![reg].into(), 0.into()),
-            Snapshot::from_raw_snapshot(vec![].into(), 0.into()),
+            Snapshot::from_raw_snapshot(
+                vec![reg].into(),
+                0.into(),
+                Fraction::from(1u64),
+                &DummyAssigner
+            )
+            .unwrap(),
+            Snapshot::from_raw_snapshot(
+                vec![].into(),
+                0.into(),
+                Fraction::from(1u64),
+                &DummyAssigner
+            )
+            .unwrap(),
         )
     }
 
@@ -225,7 +310,13 @@ mod tests {
             });
         }
 
-        let snapshot = Snapshot::from_raw_snapshot(raw_snapshot.into(), 0.into());
+        let snapshot = Snapshot::from_raw_snapshot(
+            raw_snapshot.into(),
+            0.into(),
+            Fraction::from(1u64),
+            &DummyAssigner,
+        )
+        .unwrap();
         let vp_1: u64 = snapshot
             .contributions_for_voting_key(voting_pub_key_1)
             .into_iter()
@@ -255,7 +346,9 @@ mod tests {
             }
         ]"#,
         ).unwrap();
-        let snapshot = Snapshot::from_raw_snapshot(raw, 0.into());
+        let snapshot =
+            Snapshot::from_raw_snapshot(raw, 0.into(), Fraction::from(1u64), &DummyAssigner)
+                .unwrap();
         assert_eq!(
             snapshot.contributions_for_voting_key(
                 Identifier::from_hex(

--- a/voting-hir/Cargo.toml
+++ b/voting-hir/Cargo.toml
@@ -11,3 +11,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 jormungandr-lib = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
 serde = { version = "1", features = ["derive"], optional = true }
+proptest = { git = "https://github.com/input-output-hk/proptest.git", branch = "master", optional = true }
+hex = { version = "0.4", optional = true }
+
+[features]
+proptest = ["dep:proptest", "hex"]

--- a/voting-hir/src/lib.rs
+++ b/voting-hir/src/lib.rs
@@ -2,6 +2,9 @@
 use ::serde::{Deserialize, Serialize};
 use jormungandr_lib::{crypto::account::Identifier, interfaces::Value};
 
+#[cfg(feature = "proptest")]
+pub mod proptest;
+
 pub type VotingGroup = String;
 
 /// Define High Level Intermediate Representation (HIR) for voting

--- a/voting-hir/src/proptest.rs
+++ b/voting-hir/src/proptest.rs
@@ -1,0 +1,37 @@
+use super::*;
+use ::proptest::{prelude::*, strategy::BoxedStrategy};
+use std::ops::Range;
+
+impl Arbitrary for VoterHIR {
+    type Parameters = (String, VpRange);
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        (any::<([u8; 32])>(), args.1 .0)
+            .prop_map(move |(key, voting_power)| VoterHIR {
+                voting_key: Identifier::from_hex(&hex::encode(key)).unwrap(),
+                voting_power: voting_power.into(),
+                voting_group: args.0.clone(),
+            })
+            .boxed()
+    }
+}
+
+pub struct VpRange(Range<u64>);
+
+impl VpRange {
+    pub const fn ada_distribution() -> Self {
+        Self(1..45_000_000_000)
+    }
+}
+
+impl Default for VpRange {
+    fn default() -> Self {
+        Self(0..u64::MAX)
+    }
+}
+
+impl From<Range<u64>> for VpRange {
+    fn from(range: Range<u64>) -> Self {
+        Self(range)
+    }
+}


### PR DESCRIPTION
Limit overall influence of actors in an election by capping their
maximum voting power at arbitrary levels.

Since a lot of configurations are going in the snapshot process,
I'm thinking of having it output two different artifacts:
the list of VoterHIRs, as already proposed, and another one which
is a light wrapper around VoterHIR which contains contributions
from snapshot, to be used for the reward process.

I'm proposing to keep the separate because the first one is
more general, while the second one is tied to our current
deployment and more likely to change.

### Unimplemented

The rewards cmd is going to change and I did not put too much effort there to update it. My idea was to not re-run the snapshot cmd again each time but instead use the format I proposed above, which would be automatically created in the snapshot pipeline.