### PR TITLE
rate limiting API and introduction of HTTP abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,12 @@ dependencies = [
  "chain-storage",
  "chain-time",
  "chain-vote",
+ "color-eyre",
  "csv",
+ "env_logger 0.9.0",
  "futures",
  "gag",
+ "governor",
  "graphql_client",
  "hex",
  "image",
@@ -494,6 +497,7 @@ dependencies = [
  "quircs",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "regex",
  "reqwest",
  "rust_decimal",
@@ -796,6 +800,33 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -1352,6 +1383,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1528,16 @@ dependencies = [
  "evm-core",
  "primitive-types",
  "sha3",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1739,6 +1793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1917,21 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "governor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19775995ee20209163239355bc3ad2f33f83da35d9ef72dea26e5af753552c87"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
+ "smallvec",
 ]
 
 [[package]]
@@ -2325,6 +2400,12 @@ dependencies = [
  "quote 1.0.16",
  "syn 1.0.89",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -3068,6 +3149,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,6 +3417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+
+[[package]]
 name = "parity-multiaddr"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,7 +3474,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -3390,6 +3499,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3806,7 +3928,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -3859,7 +3981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "scheduled-thread-pool",
 ]
 
@@ -4343,7 +4465,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -4636,7 +4758,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -5381,6 +5503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5947,6 +6079,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/catalyst-toolbox/Cargo.toml
+++ b/catalyst-toolbox/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 [dependencies]
 assert_fs = "1"
 bech32 = "0.8.1"
+color-eyre = "0.6"
 csv = "1.1"
 wallet = { git = "https://github.com/input-output-hk/chain-wallet-libs.git", branch = "master" }
 chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
@@ -25,6 +26,7 @@ chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch 
 chain-storage = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+env_logger = "0.9"
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 itertools = "0.10"
 jcli = { git = "https://github.com/input-output-hk/jormungandr.git", branch = "master" }
@@ -33,6 +35,7 @@ jormungandr-integration-tests = { git = "https://github.com/input-output-hk/jorm
 jormungandr-automation = { git = "https://github.com/input-output-hk/jormungandr.git",  branch = "master" }
 thor = { git = "https://github.com/input-output-hk/jormungandr.git",  branch = "master" }
 jortestkit = { git = "https://github.com/input-output-hk/jortestkit.git", branch = "master" }
+rayon = "1.5"
 rust_decimal = "1.16"
 rust_decimal_macros = "1"
 futures = "0.3"
@@ -41,6 +44,7 @@ once_cell = "1.8"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rand = "0.8.3"
 rand_chacha = "0.3"
+governor = { version = "0.4", features = ["std", "jitter"], default-features = false}
 regex = "1.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/catalyst-toolbox/src/bin/catalyst-toolbox.rs
+++ b/catalyst-toolbox/src/bin/catalyst-toolbox.rs
@@ -1,11 +1,18 @@
 use std::error::Error;
 
+use color_eyre::Report;
 use structopt::StructOpt as _;
 
 pub mod cli;
 
-fn main() {
-    cli::Cli::from_args().exec().unwrap_or_else(report_error)
+fn main() -> Result<(), Report> {
+    env_logger::init();
+    color_eyre::install()?;
+    let result = cli::Cli::from_args().exec();
+    if let Err(e) = result {
+        report_error(e);
+    }
+    Ok(())
 }
 
 fn report_error(error: Box<dyn Error>) {
@@ -15,5 +22,4 @@ fn report_error(error: Box<dyn Error>) {
         eprintln!("  |-> {}", sub_error);
         source = sub_error.source();
     }
-    std::process::exit(1)
 }

--- a/catalyst-toolbox/src/bin/cli/ideascale/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/ideascale/mod.rs
@@ -8,6 +8,8 @@ use std::collections::HashSet;
 
 use structopt::StructOpt;
 
+use catalyst_toolbox::http::default_http_client;
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -113,6 +115,8 @@ impl Import {
             stages_filters,
         } = self;
 
+        let client = default_http_client(api_token);
+
         let tags: CustomFieldTags = if let Some(tags_path) = tags {
             read_json_from_file(tags_path)?
         } else {
@@ -125,20 +129,15 @@ impl Import {
             Default::default()
         };
 
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_io()
-            .enable_time()
-            .build()?;
-
         let scores = read_scores_file(scores)?;
         let sponsors = read_sponsors_file(sponsors)?;
-        let idescale_data = runtime.block_on(fetch_all(
+        let idescale_data = fetch_all(
             *fund,
             &stage_label.to_lowercase(),
             &stages_filters.iter().map(AsRef::as_ref).collect::<Vec<_>>(),
             &excluded_proposals,
-            api_token.clone(),
-        ))?;
+            &client,
+        )?;
 
         let funds = build_fund(*fund as i32, fund_goal.clone(), *threshold);
         let challenges = build_challenges(*fund as i32, &idescale_data, sponsors);

--- a/catalyst-toolbox/src/http/mod.rs
+++ b/catalyst-toolbox/src/http/mod.rs
@@ -1,0 +1,44 @@
+use std::marker::PhantomData;
+
+use ::reqwest::{blocking::Response, StatusCode};
+use color_eyre::eyre::Result;
+use serde::Deserialize;
+
+use self::{rate_limit::RateLimitClient, reqwest::ReqwestClient};
+
+mod rate_limit;
+mod reqwest;
+
+pub fn default_http_client(api_key: &str) -> impl HttpClient {
+    RateLimitClient::new(ReqwestClient::new(api_key), 10_000)
+}
+
+#[cfg(test)]
+#[allow(unused)]
+fn test_default_client_send_sync() {
+    fn check<T: Send + Sync>(_t: T) {}
+    check(default_http_client(""));
+}
+
+/// Types which can make HTTP requests
+pub trait HttpClient:  Send + Sync + 'static {
+    fn get<T>(&self, path: &str) -> Result<HttpResponse<T>>
+    where
+        T: for<'a> Deserialize<'a>;
+}
+
+/// A value returned from a HTTP method
+pub struct HttpResponse<T: for<'a> Deserialize<'a>> {
+    _marker: PhantomData<T>,
+    inner: Response,
+}
+
+impl<T: for<'a> Deserialize<'a>> HttpResponse<T> {
+    pub fn json(self) -> Result<T> {
+        Ok(self.inner.json()?)
+    }
+
+    pub fn status(&self) -> StatusCode {
+        self.inner.status()
+    }
+}

--- a/catalyst-toolbox/src/http/mod.rs
+++ b/catalyst-toolbox/src/http/mod.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use ::reqwest::{blocking::Response, StatusCode};
 use color_eyre::eyre::Result;
+use log::warn;
 use serde::Deserialize;
 
 use self::{rate_limit::RateLimitClient, reqwest::ReqwestClient};
@@ -9,8 +10,21 @@ use self::{rate_limit::RateLimitClient, reqwest::ReqwestClient};
 mod rate_limit;
 mod reqwest;
 
+const RATE_LIMIT_ENV_VAR: &str = "CATALYST_RATE_LIMIT_MS";
+
 pub fn default_http_client(api_key: &str) -> impl HttpClient {
-    RateLimitClient::new(ReqwestClient::new(api_key), 10_000)
+    let rate_limit = match std::env::var(RATE_LIMIT_ENV_VAR).map(|s| s.parse::<u64>()) {
+        Ok(Ok(rate_limit)) => rate_limit,
+        Ok(Err(_)) => {
+            warn!(
+                "{} could not be parsed as a u64, defaulting to no rate-limiting",
+                RATE_LIMIT_ENV_VAR
+            );
+            0
+        }
+        _ => 0,
+    };
+    RateLimitClient::new(ReqwestClient::new(api_key), rate_limit)
 }
 
 #[cfg(test)]
@@ -21,7 +35,7 @@ fn test_default_client_send_sync() {
 }
 
 /// Types which can make HTTP requests
-pub trait HttpClient:  Send + Sync + 'static {
+pub trait HttpClient: Send + Sync + 'static {
     fn get<T>(&self, path: &str) -> Result<HttpResponse<T>>
     where
         T: for<'a> Deserialize<'a>;

--- a/catalyst-toolbox/src/http/rate_limit.rs
+++ b/catalyst-toolbox/src/http/rate_limit.rs
@@ -1,0 +1,40 @@
+use std::time::{Duration, Instant};
+
+use governor::{
+    clock::DefaultClock,
+    state::{InMemoryState, NotKeyed},
+    Quota, RateLimiter,
+};
+
+use color_eyre::Report;
+use log::debug;
+use serde::Deserialize;
+
+use super::{HttpClient, HttpResponse};
+
+pub struct RateLimitClient<T: HttpClient> {
+    inner: T,
+    limiter: RateLimiter<NotKeyed, InMemoryState, DefaultClock>,
+}
+
+impl<T: HttpClient> RateLimitClient<T> {
+    pub fn new(inner: T, request_interval_ms: u64) -> Self {
+        let quota = Quota::with_period(Duration::from_millis(request_interval_ms)).unwrap();
+        let limiter = RateLimiter::direct(quota);
+        Self { inner, limiter }
+    }
+}
+
+impl<T: HttpClient> HttpClient for RateLimitClient<T> {
+    fn get<S>(&self, path: &str) -> Result<HttpResponse<S>, Report>
+    where
+        S: for<'a> Deserialize<'a>,
+    {
+        while let Err(e) = self.limiter.check() {
+            let time = e.wait_time_from(Instant::now());
+            debug!("waiting for {time:?}");
+            std::thread::sleep(time);
+        }
+        self.inner.get(path)
+    }
+}

--- a/catalyst-toolbox/src/http/reqwest.rs
+++ b/catalyst-toolbox/src/http/reqwest.rs
@@ -1,0 +1,45 @@
+use color_eyre::eyre::Result;
+use reqwest::{
+    blocking::Client,
+    header::{HeaderMap, HeaderValue},
+    Url,
+};
+use serde::Deserialize;
+
+use super::{HttpClient, HttpResponse};
+
+const BASE_IDEASCALE_URL: &str = "https://cardano.ideascale.com/a/rest/v1/";
+
+pub struct ReqwestClient {
+    client: Client,
+    base_url: Url,
+}
+
+impl ReqwestClient {
+    pub fn new(api_key: &str) -> Self {
+        let mut headers = HeaderMap::new();
+        let mut auth_value = HeaderValue::from_str(api_key).unwrap();
+        auth_value.set_sensitive(true);
+        headers.insert("api_token", auth_value);
+        let client = Client::builder().default_headers(headers).build().unwrap();
+
+        Self {
+            client,
+            base_url: BASE_IDEASCALE_URL.try_into().unwrap(),
+        }
+    }
+}
+
+impl HttpClient for ReqwestClient {
+    fn get<T>(&self, path: &str) -> Result<HttpResponse<T>>
+    where
+        T: for<'a> Deserialize<'a>,
+    {
+        let url = self.base_url.join(path.as_ref())?;
+
+        Ok(HttpResponse {
+            _marker: std::marker::PhantomData,
+            inner: self.client.get(url).send()?,
+        })
+    }
+}

--- a/catalyst-toolbox/src/ideascale/fetch.rs
+++ b/catalyst-toolbox/src/ideascale/fetch.rs
@@ -30,5 +30,5 @@ pub fn get_proposals_data(
 }
 
 pub fn get_funnels_data_for_fund(client: &impl HttpClient) -> Result<Vec<Funnel>, Report> {
-    Ok(client.get("funnels")?.json()?)
+    client.get("funnels")?.json()
 }

--- a/catalyst-toolbox/src/ideascale/fetch.rs
+++ b/catalyst-toolbox/src/ideascale/fetch.rs
@@ -1,86 +1,34 @@
+use crate::http::HttpClient;
 use crate::ideascale::models::de::{Fund, Funnel, Proposal, Stage};
 
-use once_cell::sync::Lazy;
-use serde::de::DeserializeOwned;
-use url::Url;
-
+use color_eyre::Report;
+use reqwest::StatusCode;
 use std::collections::HashMap;
-use std::convert::TryInto;
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    RequestError(#[from] reqwest::Error),
-
-    #[error("Could not get value from json, missing attribute {attribute_name}")]
-    MissingAttribute { attribute_name: &'static str },
-}
 
 pub type Scores = HashMap<u32, f32>;
 pub type Sponsors = HashMap<String, String>;
 
-static BASE_IDEASCALE_URL: Lazy<url::Url> = Lazy::new(|| {
-    "https://cardano.ideascale.com/a/rest/v1/"
-        .try_into()
-        .unwrap()
-});
-
-static CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
-
-async fn request_data<T: DeserializeOwned>(api_token: String, url: Url) -> Result<T, Error> {
-    CLIENT
-        .get(url)
-        .header("api_token", api_token)
-        .send()
-        .await?
-        .json()
-        .await
-        .map_err(Error::RequestError)
+pub fn get_funds_data(client: &impl HttpClient) -> Result<Vec<Fund>, Report> {
+    client.get("campaigns/groups")?.json()
 }
 
-pub async fn get_funds_data(api_token: String) -> Result<Vec<Fund>, Error> {
-    request_data(
-        api_token,
-        BASE_IDEASCALE_URL.join("campaigns/groups").unwrap(),
-    )
-    .await
-}
-
-pub async fn get_stages(api_token: String) -> Result<Vec<Stage>, Error> {
-    request_data(api_token, BASE_IDEASCALE_URL.join("stages").unwrap()).await
+pub fn get_stages(client: &impl HttpClient) -> Result<Vec<Stage>, Report> {
+    client.get("stages")?.json()
 }
 
 /// we test token by running lightweight query and observe response code
-pub async fn is_token_valid(api_token: String) -> Result<bool, Error> {
-    let url = BASE_IDEASCALE_URL.join("profile/avatars").unwrap();
-
-    let response = CLIENT
-        .get(url)
-        .header("api_token", api_token)
-        .send()
-        .await?;
-
-    Ok(response.status() == 200)
+pub fn is_token_valid(client: &impl HttpClient) -> Result<bool, Report> {
+    Ok(client.get::<()>("profile/avatars")?.status() == StatusCode::OK)
 }
 
-pub async fn get_proposals_data(
+pub fn get_proposals_data(
+    client: &impl HttpClient,
     challenge_id: u32,
-    api_token: String,
-) -> Result<Vec<Proposal>, Error> {
-    request_data(
-        api_token,
-        BASE_IDEASCALE_URL
-            // ideascale API have some pager system which is not easy to find in the documentation
-            // https://a.ideascale.com/api-docs/index.html#/rest-api-controller-v-1/ideasByCampaignUsingGET_2
-            // in this case we want all of them, easiest way is to max out the page size.
-            .join(&format!("campaigns/{}/ideas/0/100000", challenge_id))
-            .unwrap(),
-    )
-    .await
+) -> Result<Vec<Proposal>, Report> {
+    let path = &format!("campaigns/{}/ideas/0/100000", challenge_id);
+    client.get(path)?.json()
 }
 
-pub async fn get_funnels_data_for_fund(api_token: String) -> Result<Vec<Funnel>, Error> {
-    let challenges: Vec<Funnel> =
-        request_data(api_token, BASE_IDEASCALE_URL.join("funnels").unwrap()).await?;
-    Ok(challenges)
+pub fn get_funnels_data_for_fund(client: &impl HttpClient) -> Result<Vec<Funnel>, Report> {
+    Ok(client.get("funnels")?.json()?)
 }

--- a/catalyst-toolbox/src/lib.rs
+++ b/catalyst-toolbox/src/lib.rs
@@ -14,3 +14,4 @@ pub mod vote_check;
 
 #[cfg(feature = "test-api")]
 pub mod testing;
+pub mod http;

--- a/catalyst-toolbox/src/lib.rs
+++ b/catalyst-toolbox/src/lib.rs
@@ -12,6 +12,6 @@ pub mod utils;
 pub mod vca_reviews;
 pub mod vote_check;
 
+pub mod http;
 #[cfg(feature = "test-api")]
 pub mod testing;
-pub mod http;


### PR DESCRIPTION
Adds an `HttpClient` trait for types which can make http requests, as well as a couple of implementations. There is a base http client (backed by `reqwest`), and a rate limiting client, which delegates calls to an inner client, with rate limiting.

This abstraction allows for better testability, since the implementation can be replaced with a mock client during testing

It also allows for "middleware" of a sort (e.g. this rate limiting feature)

This PR also introduces `color-eyre` for better error handling, but the benefits are somewhat limited since there are many calls that coerce the error into a `Box<dyn std::error::Error>`, which loses backtrace information on stable