### PR TITLE
remove stderrlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "chain-time",
  "chain-vote",
  "csv",
+ "env_logger 0.9.0",
  "futures",
  "gag",
  "graphql_client",
@@ -503,7 +504,6 @@ dependencies = [
  "serde_test",
  "serde_yaml",
  "sscanf",
- "stderrlog",
  "structopt",
  "symmetric-cipher",
  "test-strategy 0.2.0",
@@ -1348,6 +1348,19 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -3751,7 +3764,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -4599,19 +4612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stderrlog"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
-dependencies = [
- "atty",
- "chrono",
- "log",
- "termcolor",
- "thread_local",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,11 +4950,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/catalyst-toolbox/Cargo.toml
+++ b/catalyst-toolbox/Cargo.toml
@@ -45,7 +45,6 @@ regex = "1.5"
 serde = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
-stderrlog = "0.5"
 serde_yaml = "0.8.17"
 sscanf = "0.1"
 thiserror = "1.0"
@@ -59,6 +58,7 @@ symmetric-cipher = { git = "https://github.com/input-output-hk/chain-wallet-libs
 graphql_client = "0.10"
 gag = "1"
 vit-servicing-station-lib = { git = "https://github.com/input-output-hk/vit-servicing-station.git", branch = "master" }
+env_logger = "0.9"
 
 [dev-dependencies]
 rand_chacha = "0.3"

--- a/catalyst-toolbox/src/bin/catalyst-toolbox.rs
+++ b/catalyst-toolbox/src/bin/catalyst-toolbox.rs
@@ -5,6 +5,7 @@ use structopt::StructOpt as _;
 pub mod cli;
 
 fn main() {
+    env_logger::init();
     cli::Cli::from_args().exec().unwrap_or_else(report_error)
 }
 

--- a/catalyst-toolbox/src/bin/cli/recovery/mod.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/mod.rs
@@ -18,3 +18,18 @@ impl Recover {
         }
     }
 }
+
+fn set_verbosity(verbosity: usize) {
+    if verbosity > 0 {
+        std::env::set_var(
+            "RUST_LOG",
+            match verbosity {
+                0 => unreachable!(),
+                1 => "warn",
+                2 => "info",
+                3 => "debug",
+                _ => "trace",
+            },
+        )
+    }
+}

--- a/catalyst-toolbox/src/bin/cli/recovery/tally.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/tally.rs
@@ -14,6 +14,8 @@ use std::path::PathBuf;
 use reqwest::Url;
 use structopt::StructOpt;
 
+use super::set_verbosity;
+
 #[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -89,6 +91,8 @@ impl ReplayCli {
             output_format,
             verbose,
         } = self;
+
+        set_verbosity(verbose);
 
         let block0 = if let Some(path) = block0_path {
             read_block0(path)?

--- a/catalyst-toolbox/src/bin/cli/recovery/tally.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/tally.rs
@@ -89,7 +89,6 @@ impl ReplayCli {
             output_format,
             verbose,
         } = self;
-        stderrlog::new().verbosity(verbose).init().unwrap();
 
         let block0 = if let Some(path) = block0_path {
             read_block0(path)?

--- a/catalyst-toolbox/src/bin/cli/recovery/votes.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/votes.rs
@@ -102,18 +102,7 @@ impl VotesPrintout {
             verbose,
         } = self;
 
-        if verbose > 0 {
-            std::env::set_var(
-                "RUST_LOG",
-                match verbose {
-                    0 => unreachable!(),
-                    1 => "warn",
-                    2 => "info",
-                    3 => "debug",
-                    _ => "trace",
-                },
-            )
-        }
+        set_verbosity(verbose);
 
         let reader = std::fs::File::open(block0_path)?;
         let block0 = Block::deserialize(&mut Codec::new(reader)).unwrap();

--- a/catalyst-toolbox/src/bin/cli/recovery/votes.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/votes.rs
@@ -102,7 +102,6 @@ impl VotesPrintout {
             verbose,
         } = self;
 
-        stderrlog::new().verbosity(verbose).init().unwrap();
         let reader = std::fs::File::open(block0_path)?;
         let block0 = Block::deserialize(&mut Codec::new(reader)).unwrap();
 

--- a/catalyst-toolbox/src/bin/cli/recovery/votes.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/votes.rs
@@ -102,6 +102,19 @@ impl VotesPrintout {
             verbose,
         } = self;
 
+        if verbose > 0 {
+            std::env::set_var(
+                "RUST_LOG",
+                match verbose {
+                    0 => unreachable!(),
+                    1 => "warn",
+                    2 => "info",
+                    3 => "debug",
+                    _ => "trace",
+                },
+            )
+        }
+
         let reader = std::fs::File::open(block0_path)?;
         let block0 = Block::deserialize(&mut Codec::new(reader)).unwrap();
 

--- a/catalyst-toolbox/src/bin/cli/recovery/votes.rs
+++ b/catalyst-toolbox/src/bin/cli/recovery/votes.rs
@@ -1,4 +1,4 @@
-use super::tally::Error;
+use super::{set_verbosity, tally::Error};
 use catalyst_toolbox::recovery::tally::{
     deconstruct_account_transaction, ValidatedFragment, ValidationError, VoteFragmentFilter,
 };


### PR DESCRIPTION
Replaces `stderrlog` with `env_logger`

`stderrlog` uses a version of `thread_local` with a security vulnerability, there's an alpha version on the github that pins the dependency to a higher version, but it's not on crates.io and the repo hasn't seen activity in 3 months.

`env_logger` provides a superset of the features provided by `stderrlog`