### PR TITLE
update to latest dependencies

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+  # this is the `time` segfault
+  # `chrono` depends on `time = "0.1"`, but doesn't use the vulnerable API
+  "RUSTSEC-2020-0071"
+] 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 name = "bip39"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#f1cd62a1a1a4595fa8c3d9544b98447e8033079c"
+source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#a057240602474ee6c93d7ddc17258cab5910444e"
 dependencies = [
  "cryptoxide 0.4.2",
  "thiserror",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "cbor_event",
  "cryptoxide 0.4.2",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "bech32 0.8.1",
  "chain-core",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "chain-ser",
 ]
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "bech32 0.8.1",
  "cryptoxide 0.4.2",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "chain-evm"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "aurora-bn",
  "base64 0.13.0",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "cardano-legacy-address",
  "chain-addr",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "chain-path-derivation"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#f1cd62a1a1a4595fa8c3d9544b98447e8033079c"
+source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#a057240602474ee6c93d7ddc17258cab5910444e"
 dependencies = [
  "thiserror",
 ]
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "chain-ser"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "thiserror",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "criterion",
  "data-pile",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "chain-core",
  "chain-ser",
@@ -715,9 +715,9 @@ dependencies = [
 [[package]]
 name = "chain-vote"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "chain-core",
  "chain-crypto",
  "const_format",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "hdkeygen"
 version = "0.2.0"
-source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#f1cd62a1a1a4595fa8c3d9544b98447e8033079c"
+source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#a057240602474ee6c93d7ddc17258cab5910444e"
 dependencies = [
  "bip39",
  "cardano-legacy-address",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "hersir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 dependencies = [
  "proptest 1.0.0 (git+https://github.com/input-output-hk/proptest.git)",
  "rustc_version",
@@ -2542,7 +2542,7 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 [[package]]
 name = "jcli"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-automation"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-integration-tests"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "assert_cmd 2.0.4",
  "assert_fs",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "jormungandr-lib"
 version = "0.13.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "loki"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "chain-addr",
  "chain-core",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "mjolnir"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "assert_fs",
  "chain-addr",
@@ -4854,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 
 [[package]]
 name = "spin"
@@ -5006,7 +5006,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "symmetric-cipher"
 version = "0.5.0"
-source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#f1cd62a1a1a4595fa8c3d9544b98447e8033079c"
+source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#a057240602474ee6c93d7ddc17258cab5910444e"
 dependencies = [
  "cryptoxide 0.4.2",
  "rand 0.8.5",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "thor"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#3756504c895fec8ac0fd5f981e8951a6edd15381"
+source = "git+https://github.com/input-output-hk/jormungandr.git?branch=master#c27977964284c09505ef4e6fbc5403b311dbc224"
 dependencies = [
  "assert_fs",
  "bech32 0.8.1",
@@ -5647,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ebaf75a79489ced9d120f5330e0e13748b6aec53"
+source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#a8ac1f74eb596e27f9383f3a13e4da3fc16d8d43"
 
 [[package]]
 name = "typenum"
@@ -5883,7 +5883,7 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.6.0-pre.1"
-source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#f1cd62a1a1a4595fa8c3d9544b98447e8033079c"
+source = "git+https://github.com/input-output-hk/chain-wallet-libs.git?branch=master#a057240602474ee6c93d7ddc17258cab5910444e"
 dependencies = [
  "bip39",
  "cardano-legacy-address",

--- a/catalyst-toolbox/src/recovery/tally.rs
+++ b/catalyst-toolbox/src/recovery/tally.rs
@@ -397,7 +397,7 @@ pub fn recover_ledger_from_logs(
                 }
 
                 ledger
-                    .apply_fragment(&ledger.get_ledger_parameters(), &replayed, current_date)
+                    .apply_fragment(&replayed, current_date)
                     .map(|ledger| (ledger, replayed))
                     .map_err(|e| (Error::from(e), original.fragment))
             });


### PR DESCRIPTION
updates git dependencies, required for upcoming PR to vit-testing

Also adds an `audit.toml` to allow the `time` segfault vulnerability