### PR TITLE
mock voting group assigner in test api

### DIFF
--- a/catalyst-toolbox/src/snapshot/voting_group.rs
+++ b/catalyst-toolbox/src/snapshot/voting_group.rs
@@ -71,7 +71,7 @@ impl VotingGroupAssigner for RepsVotersAssigner {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-api"))]
 impl<F> VotingGroupAssigner for F
 where
     F: Fn(&Identifier) -> VotingGroup,


### PR DESCRIPTION
allow the implementation of `VotingGroupAssigner` for functions as part of the test api