### PR TITLE
Use integer values for rewards input/output

### DIFF
--- a/catalyst-toolbox/src/bin/cli/rewards/veterans.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/veterans.rs
@@ -2,9 +2,9 @@ use catalyst_toolbox::community_advisors::models::VeteranRankingRow;
 use catalyst_toolbox::rewards::veterans::{self, VcaRewards, VeteranAdvisorIncentive};
 use catalyst_toolbox::rewards::Rewards;
 use catalyst_toolbox::utils::csv;
-use color_eyre::eyre::bail;
+use color_eyre::eyre::{bail, eyre};
 use color_eyre::Report;
-use rust_decimal::Decimal;
+use rust_decimal::{prelude::*, Decimal};
 use serde::Serialize;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -18,9 +18,9 @@ pub struct VeteransRewards {
     /// Results file output path
     to: PathBuf,
 
-    /// Reward to be distributed
+    /// Reward to be distributed (integer value)
     #[structopt(long = "total-rewards")]
-    total_rewards: Rewards,
+    total_rewards: u64,
 
     /// Minimum number of rankings for each vca to be considered for reputation and rewards
     /// distribution
@@ -102,7 +102,7 @@ impl VeteransRewards {
 
         let results = veterans::calculate_veteran_advisors_incentives(
             &reviews,
-            total_rewards,
+            Rewards::from(total_rewards),
             min_rankings..=max_rankings_rewards,
             min_rankings..=max_rankings_reputation,
             rewards_agreement_rate_cutoffs
@@ -115,17 +115,17 @@ impl VeteransRewards {
                 .collect(),
         );
 
-        csv::dump_data_to_csv(rewards_to_csv_data(results).iter(), &to).unwrap();
+        csv::dump_data_to_csv(rewards_to_csv_data(results)?.iter(), &to).unwrap();
 
         Ok(())
     }
 }
 
-fn rewards_to_csv_data(rewards: VcaRewards) -> Vec<impl Serialize> {
+fn rewards_to_csv_data(rewards: VcaRewards) -> Result<Vec<impl Serialize>, Report> {
     #[derive(Serialize)]
     struct Entry {
         id: String,
-        rewards: Rewards,
+        rewards: u64,
         reputation: u64,
     }
 
@@ -138,10 +138,12 @@ fn rewards_to_csv_data(rewards: VcaRewards) -> Vec<impl Serialize> {
                     rewards,
                     reputation,
                 },
-            )| Entry {
-                id,
-                rewards,
-                reputation,
+            )| {
+                Ok(Entry {
+                    id,
+                    rewards: rewards.to_u64().ok_or_else(|| eyre!("Rewards overflow"))?,
+                    reputation,
+                })
             },
         )
         .collect()


### PR DESCRIPTION
Internal calculations are still done using decimal values for
better precision but input, and mainly output, are now integer
values to better support lovelaces calculation (or actually any
other token).