### PR TITLE
fix: Voter rewards registration formating

### DIFF
--- a/catalyst-toolbox/src/bin/cli/kedqr/decode/img.rs
+++ b/catalyst-toolbox/src/bin/cli/kedqr/decode/img.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 pub fn save_secret_from_qr(qr: PathBuf, output: Option<PathBuf>, pin: QrPin) -> Result<(), Report> {
-    let sk = secret_from_qr(&qr, pin)?;
+    let sk = secret_from_qr(qr, pin)?;
     let hrp = Ed25519Extended::SECRET_BECH32_HRP;
     let secret_key = bech32::encode(hrp, sk.leak_secret().to_base32(), Variant::Bech32)?;
 

--- a/catalyst-toolbox/src/bin/cli/kedqr/encode/img.rs
+++ b/catalyst-toolbox/src/bin/cli/kedqr/encode/img.rs
@@ -15,7 +15,7 @@ pub fn generate_qr(input: PathBuf, output: Option<PathBuf>, pin: QrPin) -> Resul
         .read(true)
         .write(false)
         .append(false)
-        .open(&input)
+        .open(input)
         .expect("Could not open input file.");
 
     let mut reader = BufReader::new(key_file);

--- a/catalyst-toolbox/src/bin/cli/kedqr/encode/payload.rs
+++ b/catalyst-toolbox/src/bin/cli/kedqr/encode/payload.rs
@@ -18,7 +18,7 @@ pub fn generate_payload(input: PathBuf, output: Option<PathBuf>, pin: QrPin) -> 
         .read(true)
         .write(false)
         .append(false)
-        .open(&input)
+        .open(input)
         .expect("Could not open input file.");
 
     let mut reader = BufReader::new(key_file);

--- a/catalyst-toolbox/src/bin/cli/kedqr/verify.rs
+++ b/catalyst-toolbox/src/bin/cli/kedqr/verify.rs
@@ -34,9 +34,8 @@ impl VerifyQrCodeCmd {
             if let Some(file) = &self.file {
                 vec![file.to_path_buf()]
             } else {
-                std::fs::read_dir(&self.folder.as_ref().unwrap())
+                std::fs::read_dir(self.folder.as_ref().unwrap())
                     .unwrap()
-                    .into_iter()
                     .map(|x| x.unwrap().path())
                     .collect()
             }

--- a/catalyst-toolbox/src/bin/cli/rewards/veterans.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/veterans.rs
@@ -107,11 +107,11 @@ impl VeteransRewards {
             min_rankings..=max_rankings_reputation,
             rewards_agreement_rate_cutoffs
                 .into_iter()
-                .zip(rewards_agreement_rate_modifiers.into_iter())
+                .zip(rewards_agreement_rate_modifiers)
                 .collect(),
             reputation_agreement_rate_cutoffs
                 .into_iter()
-                .zip(reputation_agreement_rate_modifiers.into_iter())
+                .zip(reputation_agreement_rate_modifiers)
                 .collect(),
         );
 

--- a/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -1,5 +1,5 @@
 use catalyst_toolbox::rewards::voters::{calc_voter_rewards, Rewards, VoteCount};
-use catalyst_toolbox::snapshot::{MainnetRewardAddress, Snapshot};
+use catalyst_toolbox::snapshot::{RewardAddress, Snapshot};
 use catalyst_toolbox::utils::assert_are_close;
 
 use color_eyre::Report;
@@ -40,7 +40,7 @@ pub struct VotersRewards {
 
 fn write_rewards_results(
     common: Common,
-    rewards: &BTreeMap<MainnetRewardAddress, Rewards>,
+    rewards: &BTreeMap<RewardAddress, Rewards>,
 ) -> Result<(), Report> {
     let writer = common.open_output()?;
     let header = ["Address", "Reward for the voter (lovelace)"];

--- a/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -45,7 +45,7 @@ fn write_rewards_results(
     let writer = common.open_output()?;
     let header = ["Address", "Reward for the voter (lovelace)"];
     let mut csv_writer = csv::Writer::from_writer(writer);
-    csv_writer.write_record(&header)?;
+    csv_writer.write_record(header)?;
 
     for (address, rewards) in rewards.iter() {
         let record = [address.to_string(), rewards.trunc().to_string()];

--- a/catalyst-toolbox/src/bin/cli/stats/archive.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/archive.rs
@@ -30,9 +30,9 @@ impl ArchiveCommand {
     pub fn exec(self) -> Result<(), Report> {
         let archiver: ArchiveStats = {
             if let Some(csv) = &self.csv {
-                load_from_csv(&csv)?.into()
+                load_from_csv(csv)?.into()
             } else if let Some(folder) = &self.folder {
-                load_from_folder(&folder)?.into()
+                load_from_folder(folder)?.into()
             } else {
                 panic!("no csv nor folder defined");
             }

--- a/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
+++ b/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
@@ -24,7 +24,7 @@ pub enum Command {
 
 impl SnapshotCommand {
     pub fn exec(&self) -> Result<(), Report> {
-        let initials: Vec<Initial> = read_initials(&jortestkit::file::read_file(&self.snapshot)?)?;
+        let initials: Vec<Initial> = read_initials(jortestkit::file::read_file(&self.snapshot)?)?;
 
         match self.command {
             Command::Count => calculate_wallet_distribution_from_initials(

--- a/catalyst-toolbox/src/ideascale/mod.rs
+++ b/catalyst-toolbox/src/ideascale/mod.rs
@@ -127,11 +127,12 @@ pub fn build_challenges(
             (
                 c.id,
                 models::se::Challenge {
+                    #[allow(clippy::obfuscated_if_else)]
                     challenge_type: funnels
                         .get(&c.funnel_id)
                         .unwrap_or_else(|| panic!("A funnel with id {} wasn't found", c.funnel_id))
                         .is_community()
-                        .then(|| "community-choice")
+                        .then_some("community-choice")
                         .unwrap_or("simple")
                         .to_string(),
                     challenge_url: c.challenge_url.clone(),

--- a/catalyst-toolbox/src/ideascale/models/de.rs
+++ b/catalyst-toolbox/src/ideascale/models/de.rs
@@ -180,9 +180,6 @@ fn deserialize_rewards<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64
         })
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| {
-            D::Error::custom(&format!(
-                "Unable to read malformed value: '{}'",
-                rewards_str
-            ))
+            D::Error::custom(format!("Unable to read malformed value: '{}'", rewards_str))
         })
 }

--- a/catalyst-toolbox/src/kedqr/img.rs
+++ b/catalyst-toolbox/src/kedqr/img.rs
@@ -47,7 +47,7 @@ pub enum QrDecodeError {
 impl KeyQrCode {
     pub fn generate(key: SecretKey<Ed25519Extended>, password: &[u8]) -> Self {
         let enc_hex = payload::generate(key, password);
-        let inner = QrCode::with_error_correction_level(&enc_hex, EcLevel::H).unwrap();
+        let inner = QrCode::with_error_correction_level(enc_hex, EcLevel::H).unwrap();
 
         KeyQrCode { inner }
     }

--- a/catalyst-toolbox/src/kedqr/payload.rs
+++ b/catalyst-toolbox/src/kedqr/payload.rs
@@ -31,7 +31,7 @@ pub fn decode<S: Into<String>>(
     password: &[u8],
 ) -> Result<SecretKey<Ed25519Extended>, Error> {
     let encrypted_bytes = hex::decode(payload.into())?;
-    let key = decrypt(password, &encrypted_bytes)?;
+    let key = decrypt(password, encrypted_bytes)?;
     Ok(SecretKey::from_binary(&key)?)
 }
 

--- a/catalyst-toolbox/src/logs/sentry.rs
+++ b/catalyst-toolbox/src/logs/sentry.rs
@@ -340,13 +340,9 @@ mod tests {
         let successful_scan_log = serde_json::json!({ "message": REGISTERED_MESSAGE });
         let unsuccessful_scan_log = serde_json::json!({ "message": MALFORMED_QR_MESSAGE });
 
-        let success_logs = (0..success)
-            .into_iter()
-            .map(|_| successful_scan_log.clone());
+        let success_logs = (0..success).map(|_| successful_scan_log.clone());
 
-        let unsuccessful_logs = (0..unssucess)
-            .into_iter()
-            .map(|_| unsuccessful_scan_log.clone());
+        let unsuccessful_logs = (0..unssucess).map(|_| unsuccessful_scan_log.clone());
 
         success_logs.chain(unsuccessful_logs).collect()
     }

--- a/catalyst-toolbox/src/recovery/replay.rs
+++ b/catalyst-toolbox/src/recovery/replay.rs
@@ -36,6 +36,7 @@ impl Replay {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn exec(self) -> Result<(), Error> {
         let fragments = load_persistent_fragments_logs_from_folder_path(&self.logs_path)
             .map_err(Error::PersistenLogsLoading)?;
@@ -53,7 +54,7 @@ impl Replay {
         let mut out_writer = self.output.open()?;
         let content = self
             .output_format
-            .format_json(serde_json::to_value(&voteplan_status)?)?;
+            .format_json(serde_json::to_value(voteplan_status)?)?;
         out_writer.write_all(content.as_bytes())?;
         Ok(())
     }

--- a/catalyst-toolbox/src/recovery/tally.rs
+++ b/catalyst-toolbox/src/recovery/tally.rs
@@ -245,6 +245,7 @@ pub struct VoteFragmentFilter<I: Iterator<Item = PersistentFragmentLog>> {
 }
 
 impl<I: Iterator<Item = PersistentFragmentLog>> VoteFragmentFilter<I> {
+    #[allow(clippy::result_large_err)]
     pub fn new(block0: Block, range_check: Range<u32>, fragments: I) -> Result<Self, Error> {
         let block0_configuration = Block0Configuration::from_block(&block0)?;
         let fees = block0_configuration.blockchain_configuration.linear_fees;
@@ -347,6 +348,7 @@ impl<I: Iterator<Item = PersistentFragmentLog>> Iterator for VoteFragmentFilter<
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub fn recover_ledger_from_logs(
     block0: &Block,
     fragment_logs: impl Iterator<Item = Result<PersistentFragmentLog, FragmentLogDeserializeError>>,
@@ -435,6 +437,7 @@ struct FragmentReplayer {
 
 impl FragmentReplayer {
     // build a new block0 with mirror accounts and same configuration as original one
+    #[allow(clippy::result_large_err)]
     fn from_block0(block0: &Block) -> Result<(Self, Block), Error> {
         let mut config =
             Block0Configuration::from_block(block0).map_err(Error::Block0ConfigurationError)?;
@@ -502,6 +505,7 @@ impl FragmentReplayer {
         ))
     }
 
+    #[allow(clippy::result_large_err)]
     fn replay_votecast(&mut self, tx: TransactionSlice<VoteCast>) -> Result<Fragment, Error> {
         let (vote_cast, identifier, _) = deconstruct_account_transaction(&tx)?;
         let address =
@@ -526,6 +530,7 @@ impl FragmentReplayer {
         Ok(res)
     }
 
+    #[allow(clippy::result_large_err)]
     fn replay_tx(&mut self, tx: TransactionSlice<NoExtra>) -> Result<Fragment, Error> {
         let (_, identifier, _) = deconstruct_account_transaction(&tx)?;
         let address =
@@ -544,9 +549,7 @@ impl FragmentReplayer {
             self.non_voting_wallets
                 .entry(address.clone())
                 .or_insert_with(|| {
-                    Wallet::new_from_key(<SecretKey<Ed25519Extended>>::generate(
-                        &mut rand::thread_rng(),
-                    ))
+                    Wallet::new_from_key(<SecretKey<Ed25519Extended>>::generate(rand::thread_rng()))
                 })
                 .account_id()
         }
@@ -576,6 +579,7 @@ impl FragmentReplayer {
     }
 
     // rebuild a fragment to be used in the new ledger configuration with the account mirror account.
+    #[allow(clippy::result_large_err)]
     fn replay(
         &mut self,
         original: ValidatedFragment,

--- a/catalyst-toolbox/src/rewards/veterans.rs
+++ b/catalyst-toolbox/src/rewards/veterans.rs
@@ -125,7 +125,7 @@ pub fn calculate_veteran_advisors_incentives(
 
     reputation_eligible_rankings
         .into_iter()
-        .zip(rewards_eligible_rankings.into_iter())
+        .zip(rewards_eligible_rankings)
         .map(|((vca, reputation), (_vca2, reward))| {
             assert_eq!(vca, _vca2); // the use of BTreeMaps ensures iteration is consistent
             (
@@ -225,11 +225,11 @@ mod tests {
             2..=2,
             THRESHOLDS
                 .into_iter()
-                .zip(REWARDS_DISAGREEMENT_MODIFIERS.into_iter())
+                .zip(REWARDS_DISAGREEMENT_MODIFIERS)
                 .collect(),
             THRESHOLDS
                 .into_iter()
-                .zip(REPUTATION_DISAGREEMENT_MODIFIERS.into_iter())
+                .zip(REPUTATION_DISAGREEMENT_MODIFIERS)
                 .collect(),
         );
         assert!(results.get(VCA_1).is_none());
@@ -254,11 +254,11 @@ mod tests {
             1..=1,
             THRESHOLDS
                 .into_iter()
-                .zip(REWARDS_DISAGREEMENT_MODIFIERS.into_iter())
+                .zip(REWARDS_DISAGREEMENT_MODIFIERS)
                 .collect(),
             THRESHOLDS
                 .into_iter()
-                .zip(REPUTATION_DISAGREEMENT_MODIFIERS.into_iter())
+                .zip(REPUTATION_DISAGREEMENT_MODIFIERS)
                 .collect(),
         );
         let res1 = results.get(VCA_1).unwrap();
@@ -304,11 +304,11 @@ mod tests {
                 1..=200,
                 THRESHOLDS
                     .into_iter()
-                    .zip(REWARDS_DISAGREEMENT_MODIFIERS.into_iter())
+                    .zip(REWARDS_DISAGREEMENT_MODIFIERS)
                     .collect(),
                 THRESHOLDS
                     .into_iter()
-                    .zip(REPUTATION_DISAGREEMENT_MODIFIERS.into_iter())
+                    .zip(REPUTATION_DISAGREEMENT_MODIFIERS)
                     .collect(),
             );
             let expected_reward_portion = agreement * Rewards::from(100) * reward_modifier;

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -85,7 +85,7 @@ fn active_addresses(
         // even if they didn't vote and the threshold is 0.
         // Active accounts are overwritten with the correct count.
         .map(|key| (key.to_hex(), 0))
-        .chain(vote_count.into_iter())
+        .chain(vote_count)
         .filter_map(|(account_hex, count)| {
             if count >= threshold {
                 Some(
@@ -219,7 +219,6 @@ mod tests {
     fn test_all_active(snapshot: Snapshot) {
         let votes_count = snapshot
             .voting_keys()
-            .into_iter()
             .map(|key| (key.to_hex(), 1))
             .collect::<VoteCount>();
         let n_voters = votes_count.len();
@@ -299,7 +298,6 @@ mod tests {
 
         let votes_count = snapshot
             .voting_keys()
-            .into_iter()
             .map(|key| (key.to_hex(), 1))
             .collect::<VoteCount>();
 

--- a/catalyst-toolbox/src/rewards/voters.rs
+++ b/catalyst-toolbox/src/rewards/voters.rs
@@ -1,4 +1,4 @@
-use crate::snapshot::{MainnetRewardAddress, Snapshot};
+use crate::snapshot::{RewardAddress, Snapshot};
 use chain_addr::{Discrimination, Kind};
 use chain_impl_mockchain::transaction::UnspecifiedAccountIdentifier;
 use chain_impl_mockchain::vote::CommitteeId;
@@ -120,7 +120,7 @@ fn account_hex_to_address(
 fn rewards_to_mainnet_addresses(
     rewards: HashMap<&'_ Address, Rewards>,
     snapshot: Snapshot,
-) -> BTreeMap<MainnetRewardAddress, Rewards> {
+) -> BTreeMap<RewardAddress, Rewards> {
     let mut res = BTreeMap::new();
     for (addr, reward) in rewards {
         let registrations = snapshot.registrations_for_voting_key(
@@ -149,7 +149,7 @@ pub fn calc_voter_rewards(
     block0: &Block0Configuration,
     snapshot: Snapshot,
     total_rewards: Rewards,
-) -> Result<BTreeMap<MainnetRewardAddress, Rewards>, Error> {
+) -> Result<BTreeMap<RewardAddress, Rewards>, Error> {
     let active_addresses = active_addresses(vote_count, block0, vote_threshold, &snapshot);
 
     let committee_keys: HashSet<Address> = block0

--- a/catalyst-toolbox/src/snapshot.rs
+++ b/catalyst-toolbox/src/snapshot.rs
@@ -6,15 +6,20 @@ use jormungandr_lib::interfaces::{Address, InitialUTxO, Stake, Value};
 use serde::{de::Error, Deserialize, Deserializer};
 use std::iter::Iterator;
 
-pub type MainnetRewardAddress = String;
-pub type MainnetStakeAddress = String;
+const MAINNET_PAYMENT_PREFIX: &str = "addr";
+const TESTNET_PAYMENT_PREFIX: &str = "addr_test";
+const MAINNET_STAKE_PREFIX: &str = "stake";
+const TESTNET_STAKE_PREFIX: &str = "stake_test";
 
-#[derive(Deserialize, Clone, Debug)]
+pub type RewardAddress = String;
+pub type StakeAddress = String;
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CatalystRegistration {
-    pub stake_public_key: MainnetStakeAddress,
+    pub stake_public_key: StakeAddress,
     pub voting_power: Stake,
     #[serde(deserialize_with = "reward_addr_from_hex")]
-    pub rewards_address: MainnetRewardAddress,
+    pub rewards_address: RewardAddress,
     #[serde(deserialize_with = "identifier_from_hex")]
     pub delegations: Identifier,
 }
@@ -143,14 +148,70 @@ where
         .map_err(|e| D::Error::custom(format!("invalid public key {}", e)))
 }
 
-fn reward_addr_from_hex<'de, D>(deserializer: D) -> Result<MainnetRewardAddress, D::Error>
+fn reward_addr_from_hex<'de, D>(deserializer: D) -> Result<RewardAddress, D::Error>
 where
     D: Deserializer<'de>,
 {
+    enum AddrType {
+        Shelley,
+        Stake,
+    }
+    enum NetType {
+        Mainnet,
+        Testnet,
+    }
+
+    // Following cip-0019 specification https://github.com/cardano-foundation/CIPs/blob
     use bech32::ToBase32;
     let bytes = hex::decode(String::deserialize(deserializer)?.trim_start_matches("0x"))
         .map_err(|e| D::Error::custom(format!("invalid hex string: {}", e)))?;
-    bech32::encode("stake", &bytes.to_base32(), bech32::Variant::Bech32)
+
+    let addr_prefix = bytes
+        .first()
+        .ok_or_else(|| D::Error::custom("invalid address format"))?;
+
+    // Shelley addrs: 0x0?, 0x1?, 0x2?, 0x3?, 0x4?, 0x5?, 0x6?, 0x7?
+    // Stake addrs: 0xE?, 0xF?
+    let addr_type = addr_prefix >> 4 & 0xf;
+    // 0 or 1 are valid addrs in the following cases:
+    // type = 0x0 -  Testnet network
+    // type = 0x1 -  Mainnet network
+    let addr_net = addr_prefix & 0xf;
+
+    let addr_type = match addr_type {
+        // Shelley
+        0x0 | 0x1 | 0x2 | 0x3 | 0x4 | 0x5 | 0x6 | 0x7 => AddrType::Shelley,
+        // Stake
+        0xf | 0xe => AddrType::Stake,
+        _ => {
+            return Err(D::Error::custom(format!(
+                "invalid address format, incorrect addr type: {}",
+                addr_type
+            )))
+        }
+    };
+
+    let addr_net = match addr_net {
+        // Mainnet
+        0x1 => NetType::Mainnet,
+        // Testnet
+        0x0 => NetType::Testnet,
+        _ => {
+            return Err(D::Error::custom(format!(
+                "invalid address format, incorrect network tag: {}",
+                addr_net
+            )))
+        }
+    };
+
+    let prefix = match (addr_type, addr_net) {
+        (AddrType::Shelley, NetType::Mainnet) => MAINNET_PAYMENT_PREFIX,
+        (AddrType::Stake, NetType::Mainnet) => MAINNET_STAKE_PREFIX,
+        (AddrType::Shelley, NetType::Testnet) => TESTNET_PAYMENT_PREFIX,
+        (AddrType::Stake, NetType::Testnet) => TESTNET_STAKE_PREFIX,
+    };
+
+    bech32::encode(prefix, bytes.to_base32(), bech32::Variant::Bech32)
         .map_err(|e| D::Error::custom(format!("bech32 encoding failed: {}", e)))
 }
 
@@ -247,9 +308,84 @@ mod tests {
                 "voting_purpose": 0,
                 "tx_id": 70591630,
                 "nonce": 96778096
+            },
+            {
+                "delegations": "0xe8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3",
+                "rewards_address": "0x00cd3be59b212a45b99f2d26bd179c7119e2851c3b7ada415eff504683c7a5c447ebee137a684b65750e8ab5227ffb3199017bdaf069464c11",
+                "stake_public_key": "0x76d416ebfc0a6044b7b00afeeafea330ad1ee2dc3f63b9c4fc5fb685f1dfef01",
+                "voting_power": 0,
+                "voting_purpose": null,
+                "tx_id": 10554899,
+                "nonce": 37222821
+            },
+            {
+                "delegations": "0xe8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3",
+                "rewards_address": "0xe0b8d7b8e56a3ed89ee21bc062d284d537f843b50b68b905618b130297",
+                "stake_public_key": "0x76d416ebfc0a6044b7b00afeeafea330ad1ee2dc3f63b9c4fc5fb685f1dfef01",
+                "voting_power": 0,
+                "voting_purpose": null,
+                "tx_id": 10554899,
+                "nonce": 37222821
             }
         ]"#,
         ).unwrap();
-        Snapshot::from_raw_snapshot(raw, 0.into());
+
+        assert_eq!(raw.0.len(), 4);
+        assert_eq!(
+            raw.0[0],
+            CatalystRegistration {
+                stake_public_key:
+                    "0x76d416ebfc0a6044b7b00afeeafea330ad1ee2dc3f63b9c4fc5fb685f1dfef01".to_string(),
+                voting_power: 0.into(),
+                delegations: Identifier::from_hex(
+                    "e8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3"
+                )
+                .unwrap(),
+                rewards_address: "stake1u9mvc5r26hfcghs02y6ye2ykvqxl0h4ljm6c7jhncyzxhkg2dz3ks"
+                    .to_string(),
+            }
+        );
+        assert_eq!(
+            raw.0[1],
+            CatalystRegistration {
+                stake_public_key:
+                    "0xd96073e70e5c426463e6c5f732712939daa0c6c35313dd989752c7cb672b0b4c".to_string(),
+                voting_power: 41248637318.into(),
+                delegations: Identifier::from_hex(
+                    "221fc1fbcc4abb38c425a922a048af6d492d1260d1b6f055e129385e18f2c603"
+                )
+                .unwrap(),
+                rewards_address: "addr1q963f0c3dcmztv7n7560krprhxg5sa4ls2axjej5x6ydl7eh9khkdshunfw3j3f6fapfwywt5whwdt5a0pp9cgaw42zsgxgmxz"
+                    .to_string(),
+            }
+        );
+        assert_eq!(
+            raw.0[2],
+            CatalystRegistration {
+                stake_public_key:
+                    "0x76d416ebfc0a6044b7b00afeeafea330ad1ee2dc3f63b9c4fc5fb685f1dfef01".to_string(),
+                voting_power: 0.into(),
+                delegations: Identifier::from_hex(
+                    "e8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3"
+                )
+                .unwrap(),
+                rewards_address: "addr_test1qrxnhevmyy4ytwvl95nt69uuwyv79pgu8dad5s27lagydq785hzy06lwzdaxsjm9w58g4dfz0lanrxgp00d0q62xfsgs5gsfhq"
+                    .to_string(),
+            }
+        );
+        assert_eq!(
+            raw.0[3],
+            CatalystRegistration {
+                stake_public_key:
+                    "0x76d416ebfc0a6044b7b00afeeafea330ad1ee2dc3f63b9c4fc5fb685f1dfef01".to_string(),
+                voting_power: 0.into(),
+                delegations: Identifier::from_hex(
+                    "e8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3"
+                )
+                .unwrap(),
+                rewards_address: "stake_test1uzud0w89dgld38hzr0qx955y65mlssa4pd5tjptp3vfs99c4m0ve4"
+                    .to_string(),
+            }
+        );
     }
 }

--- a/catalyst-toolbox/src/snapshot.rs
+++ b/catalyst-toolbox/src/snapshot.rs
@@ -77,7 +77,7 @@ impl Snapshot {
                     .map(|reg| {
                         let value = u64::from(reg.voting_power);
                         if in_lovelace {
-                            value / 1_000_000 as u64
+                            value / 1_000_000_u64
                         } else {
                             value
                         }
@@ -180,7 +180,7 @@ where
 
     let addr_type = match addr_type {
         // Shelley
-        0x0 | 0x1 | 0x2 | 0x3 | 0x4 | 0x5 | 0x6 | 0x7 => AddrType::Shelley,
+        0x0..=0x7 => AddrType::Shelley,
         // Stake
         0xf | 0xe => AddrType::Stake,
         _ => {
@@ -232,7 +232,7 @@ mod tests {
                 .prop_map(|((stake_key, rewards_addr, voting_key), vp)| {
                     let stake_public_key = hex::encode(stake_key);
                     let reward_address =
-                        bech32::encode("stake", &rewards_addr.to_base32(), bech32::Variant::Bech32)
+                        bech32::encode("stake", rewards_addr.to_base32(), bech32::Variant::Bech32)
                             .unwrap();
                     let voting_public_key = <SecretKey<Ed25519>>::from_binary(&voting_key)
                         .expect("every binary sequence is a valid secret key")

--- a/catalyst-toolbox/src/snapshot.rs
+++ b/catalyst-toolbox/src/snapshot.rs
@@ -161,7 +161,7 @@ where
         Testnet,
     }
 
-    // Following cip-0019 specification https://github.com/cardano-foundation/CIPs/blob
+    // Following cip-0019 specification https://cips.cardano.org/cips/cip19/
     use bech32::ToBase32;
     let bytes = hex::decode(String::deserialize(deserializer)?.trim_start_matches("0x"))
         .map_err(|e| D::Error::custom(format!("invalid hex string: {}", e)))?;

--- a/catalyst-toolbox/src/stats/live/harvester.rs
+++ b/catalyst-toolbox/src/stats/live/harvester.rs
@@ -47,7 +47,7 @@ impl Harvester {
             .build()?;
 
         let res = client
-            .get(&format!("{}/v0/fragment/logs", self.endpoint))
+            .get(format!("{}/v0/fragment/logs", self.endpoint))
             .send()?;
         serde_json::from_str(&res.text()?).map_err(Into::into)
     }

--- a/catalyst-toolbox/tests/tally/blockchain.rs
+++ b/catalyst-toolbox/tests/tally/blockchain.rs
@@ -103,7 +103,6 @@ impl TestBlockchainBuilder {
 
         let mut initial = Vec::with_capacity(self.n_wallets as usize + self.n_committees as usize);
         let mut wallets = (0..self.n_wallets + self.n_committees as u32)
-            .into_iter()
             .map(|_| {
                 let funds = rng.gen_range(MIN_FUNDS..MAX_FUNDS);
                 let wallet =

--- a/catalyst-toolbox/tests/tally/generator.rs
+++ b/catalyst-toolbox/tests/tally/generator.rs
@@ -45,7 +45,7 @@ fn account_from_slice<P>(
     }
 }
 
-impl<'a> VoteRoundGenerator {
+impl VoteRoundGenerator {
     pub fn new(blockchain: TestBlockchain) -> Self {
         let TestBlockchain {
             config,
@@ -225,7 +225,7 @@ impl<'a> VoteRoundGenerator {
                         let decrypted_tally = DecryptedPrivateTally::new(
                             results
                                 .into_iter()
-                                .zip(shares.into_iter())
+                                .zip(shares)
                                 .map(|(tally_result, decrypt_shares)| {
                                     DecryptedPrivateTallyProposal {
                                         decrypt_shares,

--- a/catalyst-toolbox/tests/tally/main.rs
+++ b/catalyst-toolbox/tests/tally/main.rs
@@ -99,9 +99,7 @@ fn tally_ok() {
 
     let (ledger, failed_fragments) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vote_fragments
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vote_fragments.into_iter().chain(tally_fragments),
     )
     .unwrap();
 
@@ -127,9 +125,7 @@ fn shuffle_tally_ok() {
 
     let (ledger, _) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vote_fragments
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vote_fragments.into_iter().chain(tally_fragments),
     )
     .unwrap();
 
@@ -153,9 +149,7 @@ fn shuffle_tally_ok_private() {
 
     let (ledger, _) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vote_fragments
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vote_fragments.into_iter().chain(tally_fragments),
     )
     .unwrap();
 
@@ -196,7 +190,7 @@ fn wallet_not_in_block0() {
                 time: jump_to_epoch(0, generator.block0_config()),
                 fragment,
             })))
-            .chain(tally_fragments.into_iter()),
+            .chain(tally_fragments),
     )
     .unwrap();
 
@@ -242,7 +236,7 @@ fn only_last_vote_is_counted() {
                     fragment,
                 })
             })
-            .chain(tally_fragments.into_iter()),
+            .chain(tally_fragments),
     )
     .unwrap();
 
@@ -289,7 +283,7 @@ fn replay_not_counted() {
                     fragment,
                 })
             })
-            .chain(tally_fragments.into_iter()),
+            .chain(tally_fragments),
     )
     .unwrap();
 
@@ -323,9 +317,7 @@ fn multi_voteplan_ok() {
 
     let (ledger, _) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vote_fragments
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vote_fragments.into_iter().chain(tally_fragments),
     )
     .unwrap();
 
@@ -353,9 +345,7 @@ fn multi_voteplan_ok_private() {
 
     let (ledger, _) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vote_fragments
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vote_fragments.into_iter().chain(tally_fragments),
     )
     .unwrap();
 
@@ -508,7 +498,7 @@ fn transaction_transfer_does_not_decrease_voting_power() {
         &generator.block0(),
         vec![transaction, fragment_yes, fragment_no]
             .into_iter()
-            .chain(tally_fragments.into_iter()),
+            .chain(tally_fragments),
     )
     .unwrap();
 
@@ -551,9 +541,7 @@ fn expired_transaction() {
 
     let (ledger, failed_fragments) = catalyst_toolbox::recovery::tally::recover_ledger_from_logs(
         &generator.block0(),
-        vec![fragment_yes]
-            .into_iter()
-            .chain(tally_fragments.into_iter()),
+        vec![fragment_yes].into_iter().chain(tally_fragments),
     )
     .unwrap();
 


### PR DESCRIPTION
- Fixed `delegations` snapshot field parsing, so now it can process old and new registrations.
Old:
```
"delegations": "0xe8322036dd13fa4576b0e6abe51150c040fc5a9f20a94ecbd918986023354ba3",
```
New:
```
"delegations": [["0x221fc1fbcc4abb38c425a922a048af6d492d1260d1b6f055e129385e18f2c603", 1]]
```
- ported this update https://github.com/input-output-hk/catalyst-core/pull/503